### PR TITLE
[기능] jacoco 와 codecov 연동 (#35)

### DIFF
--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
 
     permissions:
@@ -50,3 +51,10 @@ jobs:
       if: ${{ always() }}
       with:
         files: ./knowlly-core/build/test-results/**/*.xml
+
+    - name: Report Codecov Test Coverage
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./knowlly-core/build/reports/jacoco/test/jacocoTestReport.xml
+        name: knowlly-codedev
+        verbose: true

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects {
 		reports {
 			html.destination file("${buildDir}/jacocoHtml")
 			csv.enabled false
-			xml.enabled false
+			xml.enabled true
 		}
 
 		finalizedBy 'jacocoTestCoverageVerification'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: yes
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false
+  branches:
+    - main


### PR DESCRIPTION
## 작업 내용 설명
- jacoco로 실행한 테스트 커버리지 보고서를 codecov에 업로드하여 리포트를 생성합니다.
- github pr시 측정된 커버리지를 코멘트로 확인할 수 있도록 합니다.

## 주요 변경 사항
- github action workflow에 jacoco보고서를 codecov로 업로드 하는 플로우 추가
- codecov.yml 설정 추가
    - PR시 코멘트를 달 수 있도록 하는 설정 포함
    - TMI) 버그인지는 모르겠는데 codecov에서 해당 파일을 인식 못해서, codecov 페이지에서 global 설정함

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #35 

@NaLDo627 @Park-Young-Hun
