### PR TITLE
[수정] User 테이블에서 email 제약조건 제거 (#49)

### DIFF
--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/entity/User.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/entity/User.java
@@ -19,7 +19,7 @@ public class User {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column
     private String email;
 
     @Column(nullable = false)

--- a/knowlly-core/src/main/resources/config/liquibase/changelog/20220615_drop_constraint_from_user.xml
+++ b/knowlly-core/src/main/resources/config/liquibase/changelog/20220615_drop_constraint_from_user.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="20220615" author="hkpark">
+        <addColumn tableName="user">
+            <column name="email_temp" type="VARCHAR(255)">
+                <constraints nullable="true" unique="false" />
+            </column>
+        </addColumn>
+        <update tableName="user">
+            <column name="email_temp" type="varchar(255)" valueComputed="email"/>
+        </update>
+        <dropColumn columnName="email" tableName="user"/>
+        <renameColumn tableName="user" oldColumnName="email_temp" newColumnName="email"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/knowlly-core/src/main/resources/config/liquibase/changelog/20220615_drop_constraint_from_user.xml
+++ b/knowlly-core/src/main/resources/config/liquibase/changelog/20220615_drop_constraint_from_user.xml
@@ -9,15 +9,15 @@
 
     <changeSet id="20220615" author="hkpark">
         <addColumn tableName="user">
-            <column name="email_temp" type="VARCHAR(255)">
-                <constraints nullable="true" unique="false" />
+            <column name="email_temp" type="varchar(255)">
+                <constraints nullable="true" unique="false"/>
             </column>
         </addColumn>
         <update tableName="user">
             <column name="email_temp" type="varchar(255)" valueComputed="email"/>
         </update>
         <dropColumn columnName="email" tableName="user"/>
-        <renameColumn tableName="user" oldColumnName="email_temp" newColumnName="email"/>
+        <renameColumn tableName="user" oldColumnName="email_temp" newColumnName="email" columnDataType="varchar(255)"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/knowlly-core/src/main/resources/config/liquibase/master.xml
+++ b/knowlly-core/src/main/resources/config/liquibase/master.xml
@@ -10,4 +10,5 @@
     <include file="config/liquibase/changelog/00000000_initial_schema.xml"/>
     <include file="config/liquibase/changelog/20220613_kakao_id_change.xml"/>
     <include file="config/liquibase/changelog/20220614_add_portfolio_column.xml"/>
+    <include file="config/liquibase/changelog/20220615_drop_constraint_from_user.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
## 작업 내용 설명
- User 테이블의 email 컬럼에서 not null, unique 제약조건을 제거한다. (email이 선택사항이 될 것 같기 때문)

## 주요 변경 사항
- liquibase 상으로 제약조건 drop이 어려워서, 컬럼을 새로 만들고, 데이터를 옮기고, 삭제하는 방향으로 작업
- 엔티티 email 필드 어노테이션 업데이트

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #49 

@NaLDo627 @Park-Young-Hun
