### PR TITLE
[추가] 로그인 / 회원가입 관련 플로우 추가 (#23)

### DIFF
--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -53,8 +53,8 @@ jobs:
       if: ${{ always() }}
       with:
         files: | 
-        ./knowlly-core/build/test-results/**/*.xml
-        ./knowlly-api/build/test-results/**/*.xml
+            ./knowlly-core/build/test-results/**/*.xml
+            ./knowlly-api/build/test-results/**/*.xml
 
     - name: Report Codecov Test Coverage
       uses: codecov/codecov-action@v2

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -52,11 +52,13 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@v1
       if: ${{ always() }}
       with:
-        files: ./knowlly-core/build/test-results/**/*.xml
+        files: | 
+        ./knowlly-core/build/test-results/**/*.xml
+        ./knowlly-api/build/test-results/**/*.xml
 
     - name: Report Codecov Test Coverage
       uses: codecov/codecov-action@v2
       with:
-        files: ./knowlly-core/build/reports/jacoco/test/jacocoTestReport.xml
+        files: ./knowlly-core/build/reports/jacoco/test/jacocoTestReport.xml,./knowlly-api/build/reports/jacoco/test/jacocoTestReport.xml
         name: knowlly-codedev
         verbose: true

--- a/build.gradle
+++ b/build.gradle
@@ -55,22 +55,37 @@ subprojects {
 		annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
 	}
 
-	tasks.named('test') {
+	test {
 		useJUnitPlatform()
 		finalizedBy 'jacocoTestReport'
 	}
 
-	tasks.named('jacocoTestReport') {
+	jacocoTestReport {
 		reports {
 			html.destination file("${buildDir}/jacocoHtml")
 			csv.enabled false
 			xml.enabled true
 		}
 
+		afterEvaluate {
+			classDirectories.setFrom(files(classDirectories.files.collect {
+				fileTree(dir: it, exclude: [
+						"**/*Knowlly*Application*",
+						"**/config/*",
+						"**/exception/*",
+						"**/dto/*",
+						"**/advice/*",
+						"**/util/*",
+						"**/core/core/**/*",
+						"**/core/web/*",
+				])
+			}))
+		}
+
 		finalizedBy 'jacocoTestCoverageVerification'
 	}
 
-	tasks.named('jacocoTestCoverageVerification') {
+	jacocoTestCoverageVerification {
 		violationRules {
 			rule {
 				enabled = true
@@ -83,8 +98,14 @@ subprojects {
 				}
 
 				excludes = [
-				        "*BasePackage*",
-				        "*Knowlly*Application*",
+				        "**/*Knowlly*Application*",
+				        "**/config/*",
+				        "**/exception/*",
+				        "**/dto/*",
+				        "**/advice/*",
+				        "**/util/*",
+				        "**/core/core/**/*",
+						"**/api/core/web/*",
 				]
 			}
 

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,9 @@ project(':knowlly-api') {
 		implementation 'org.springframework.boot:spring-boot-starter-web'
 		implementation 'io.springfox:springfox-swagger2:2.9.2'
 		implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+		implementation 'org.springframework.boot:spring-boot-starter-security'
+		implementation 'io.jsonwebtoken:jjwt:0.9.1'
+		implementation 'org.springframework.security:spring-security-test'
 	}
 }
 

--- a/deployment/deployment-dev.yml
+++ b/deployment/deployment-dev.yml
@@ -26,7 +26,7 @@ spec:
             - containerPort: 8080
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/test
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/advice/AbstractControllerAdvice.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/advice/AbstractControllerAdvice.java
@@ -1,0 +1,22 @@
+package kr.co.knowledgerally.api.core.advice;
+
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * 추상 컨트롤러 어드바이스
+ */
+@Slf4j
+public abstract class AbstractControllerAdvice {
+    protected ResponseEntity<ApiResult<?>> handleException(Throwable e, HttpStatus status) {
+        log.error(e.getMessage(), e);
+        return handleException(e, status, status.value());
+    }
+
+    protected ResponseEntity<ApiResult<?>> handleException(Throwable e, HttpStatus status, int errorCode) {
+        return ResponseEntity.status(status)
+                .body(ApiResult.fail(e.getMessage()));
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/advice/DefaultControllerAdvice.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/advice/DefaultControllerAdvice.java
@@ -1,0 +1,43 @@
+package kr.co.knowledgerally.api.core.advice;
+
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.core.core.exception.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.annotation.Priority;
+
+/**
+ * 기본 컨트롤러 어드바이스, 사실상 그냥 예외 핸들러
+ */
+@Priority(20)
+@RestControllerAdvice
+public class DefaultControllerAdvice extends AbstractControllerAdvice {
+    @ExceptionHandler(value = { Exception.class, KnowllyException.class })
+    public ResponseEntity<ApiResult<?>> handleUnknownException(Exception e) {
+        return handleException(e, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(value = { BadRequestException.class })
+    public ResponseEntity<ApiResult<?>> handleBadRequestException(Exception e) {
+        return handleException(e, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(value = { ResourceNotFoundException.class})
+    public ResponseEntity<ApiResult<?>> handleNotFoundException(Exception e) {
+        return handleException(e, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = { AccessNotAllowedException.class})
+    public ResponseEntity<ApiResult<?>> handleForbiddenException(Exception e) {
+        return handleException(e, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(value = { UnauthorizedException.class})
+    public ResponseEntity<ApiResult<?>> handleUnauthorizedException(Exception e) {
+        return handleException(e, HttpStatus.UNAUTHORIZED);
+    }
+
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/advice/ValidationControllerAdvice.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/advice/ValidationControllerAdvice.java
@@ -1,0 +1,27 @@
+package kr.co.knowledgerally.api.core.advice;
+
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.annotation.Priority;
+
+/**
+ * 유효 검증 예외 처리 어드바이스
+ */
+@Priority(5)
+@RestControllerAdvice
+public class ValidationControllerAdvice extends AbstractControllerAdvice {
+    @ExceptionHandler(value = { MethodArgumentNotValidException.class })
+    public ResponseEntity<ApiResult<?>> handleValidationException(MethodArgumentNotValidException e) {
+        FieldError fieldError = e.getBindingResult().getFieldErrors().get(0);
+        String message = String.format("[%s : %s]",
+                fieldError.getField(), fieldError.getDefaultMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResult.fail(message));
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/annotation/CurrentUser.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/annotation/CurrentUser.java
@@ -1,0 +1,14 @@
+package kr.co.knowledgerally.api.core.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface CurrentUser {
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/RestTemplateConfig.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/RestTemplateConfig.java
@@ -1,0 +1,26 @@
+package kr.co.knowledgerally.api.core.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .requestFactory(() -> new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
+                .setConnectTimeout(Duration.ofMillis(5000)) // connection-timeout
+                .setReadTimeout(Duration.ofMillis(5000)) // read-timeout
+                .additionalMessageConverters(new StringHttpMessageConverter(StandardCharsets.UTF_8))
+                .build();
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/SecurityConfig.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/SecurityConfig.java
@@ -1,0 +1,57 @@
+package kr.co.knowledgerally.api.core.config;
+
+import kr.co.knowledgerally.api.core.jwt.component.JwtAuthenticationEntryPoint;
+import kr.co.knowledgerally.api.core.jwt.component.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    public static final String[] EXCLUDED_URLS = {
+            "/api/test*",
+            "/api/user/user-exists",
+            "/api/user/signin",
+            "/api/user/refresh",
+            "/api/user/signup",
+    };
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .httpBasic().disable()
+                .csrf().disable()
+                .exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                    .authorizeRequests()
+                        .antMatchers(EXCLUDED_URLS).permitAll()
+                        .anyRequest().authenticated()
+                .and()
+                    .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/v2/api-docs", "/configuration/ui",
+                                "/swagger-resources/**", "/configuration/security",
+                                "/swagger-ui.html", "/webjars/**","/swagger/**"); 
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/dto/ApiPageRequest.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/dto/ApiPageRequest.java
@@ -1,0 +1,37 @@
+package kr.co.knowledgerally.api.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.core.core.exception.BadRequestException;
+import lombok.*;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.stream.Stream;
+
+/**
+ * 페이징 API 요청 모델
+ */
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value="페이징 API 요청 모델")
+@EqualsAndHashCode
+public class ApiPageRequest {
+    @ApiModelProperty(value = "요청 페이지 번호 (0부터 시작)", example = "0")
+    private int page = 0;
+
+    @ApiModelProperty(value = "요청 페이지 크기 (기본 : 10)", example = "10")
+    private int size = 10;
+
+    public Pageable convert() {
+        return PageRequest.of(page, size);
+    }
+
+    public Pageable convertWithNewestSort() {
+        return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/dto/ApiPageResult.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/dto/ApiPageResult.java
@@ -1,0 +1,45 @@
+package kr.co.knowledgerally.api.core.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * 페이징 API 응답 모델
+ * @param <T> DTO 클래스 타입
+ */
+@Getter
+@ApiModel(value="페이징 API 응답 모델")
+public class ApiPageResult<T> extends ApiResult<List<T>> {
+
+    @ApiModelProperty(value = "페이지 번호", position = 2)
+    private final int currentPage;
+
+    @ApiModelProperty(value = "총합 페이지", position = 3)
+    private final int totalPage;
+
+    @ApiModelProperty(value = "페이지 크기", position = 4)
+    private final int pageSize;
+
+    @ApiModelProperty(value = "전체 개수",  position = 5)
+    private final long totalElements;
+
+    public ApiPageResult(Page<T> data, String message) {
+        super(message, data.getContent());
+        this.currentPage = data.getPageable().getPageNumber();
+        this.pageSize = data.getPageable().getPageSize();
+        this.totalPage = data.getTotalPages();
+        this.totalElements = data.getTotalElements();
+    }
+
+    public static <T> ApiPageResult<T> ok(Page<T> data) {
+        return ok(data, "ok");
+    }
+
+    public static <T> ApiPageResult<T> ok(Page<T> data, String message) {
+        return new ApiPageResult<>(data, message);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/dto/ApiResult.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/dto/ApiResult.java
@@ -1,0 +1,41 @@
+package kr.co.knowledgerally.api.core.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+/**
+ * API 응답 공통 모델
+ * @param <T> DTO 클래스 타입
+ */
+@Getter
+@ApiModel(value="API 응답 공통 모델")
+public class ApiResult<T> {
+
+    @ApiModelProperty(value = "결과 메세지", position = 0)
+    protected final String message;
+
+    @ApiModelProperty(value = "응답 데이터, 실패시 null", position = 1)
+    protected final T data;
+
+    @ApiModelProperty(value = "요청 서버 시간", position = 5)
+    protected final long timestamp;
+
+    public ApiResult(String message, T data) {
+        this.message = message;
+        this.data = data;
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    public static <T> ApiResult<T> ok(T data) {
+        return ok(data, "ok");
+    }
+
+    public static <T> ApiResult<T> ok(T data, String message) {
+        return new ApiResult<>(message, data);
+    }
+
+    public static ApiResult<?> fail(String message) {
+        return new ApiResult<>(message, null);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtAuthenticationEntryPoint.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package kr.co.knowledgerally.api.core.jwt.component;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import springfox.documentation.spring.web.json.Json;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        String json = JsonMapper.builder().build().writeValueAsString(ApiResult.fail("Unauthorized"));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        PrintWriter writer = response.getWriter();
+        writer.write(json);
+        writer.flush();
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtAuthenticationFilter.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtAuthenticationFilter.java
@@ -1,11 +1,8 @@
 package kr.co.knowledgerally.api.core.jwt.component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.knowledgerally.api.core.dto.ApiResult;
 import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -32,7 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try {
                 setAuthToSecurityContextHolder(token);
             } catch (ResourceNotFoundException e) {
-                writeNotFoundResponse(servletResponse, e);
+                log.error("토큰에 해당하는 사용자가 없습니다.", e);
             }
         }
 
@@ -42,20 +39,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void setAuthToSecurityContextHolder(String token) {
         Authentication auth = jwtResolver.getAuthentication(token);
         SecurityContextHolder.getContext().setAuthentication(auth);
-    }
-
-    private void writeNotFoundResponse(HttpServletResponse response, ResourceNotFoundException ex) {
-        final String msg = "토큰에 해당하는 사용자가 없습니다.";
-        log.error(msg);
-        response.setStatus(HttpStatus.NOT_FOUND.value());
-        response.setContentType("application/json");
-        ApiResult<?> errorResponse = ApiResult.fail(msg);
-        try{
-            ObjectMapper mapper = new ObjectMapper();
-            String json = mapper.writeValueAsString(errorResponse);
-            response.getWriter().write(json);
-        }catch (IOException e){
-            log.error("Json failed : ", e);
-        }
     }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtAuthenticationFilter.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package kr.co.knowledgerally.api.core.jwt.component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtResolver jwtResolver;
+    private final JwtValidator jwtValidator;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        String token = jwtResolver.resolveToken(servletRequest);
+
+        if (jwtValidator.validateToken(token)) {
+            try {
+                setAuthToSecurityContextHolder(token);
+            } catch (ResourceNotFoundException e) {
+                writeNotFoundResponse(servletResponse, e);
+            }
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private void setAuthToSecurityContextHolder(String token) {
+        Authentication auth = jwtResolver.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    private void writeNotFoundResponse(HttpServletResponse response, ResourceNotFoundException ex) {
+        final String msg = "토큰에 해당하는 사용자가 없습니다.";
+        log.error(msg);
+        response.setStatus(HttpStatus.NOT_FOUND.value());
+        response.setContentType("application/json");
+        ApiResult<?> errorResponse = ApiResult.fail(msg);
+        try{
+            ObjectMapper mapper = new ObjectMapper();
+            String json = mapper.writeValueAsString(errorResponse);
+            response.getWriter().write(json);
+        }catch (IOException e){
+            log.error("Json failed : ", e);
+        }
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtCreator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtCreator.java
@@ -1,0 +1,64 @@
+package kr.co.knowledgerally.api.core.jwt.component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import kr.co.knowledgerally.core.core.component.DateFactory;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성기
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtCreator { // TODO 유효시간 설정 외부 설정값으로 변경
+    private static final long ACCESS_TOKEN_VALID_MILISECOND = 1000 * 60 * 60 * 24; // 24 시간
+    private static final long REFRESH_TOKEN_VALID_MILISECOND = 1000L * 60 * 60 * 24 * 30 * 2; // 2달
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    private final DateFactory dateFactory;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    /**
+     * JWT Access Token 발급
+     * @param user 사용자
+     * @return Jwt 토큰
+     */
+    public String createAccessToken(User user) {
+        return createToken(user, ACCESS_TOKEN_VALID_MILISECOND);
+    }
+
+    /**
+     * JWT Refresh Token 발급
+     * @param user 사용자
+     * @return Jwt 토큰
+     */
+    public String createRefreshToken(User user) {
+        return createToken(user, REFRESH_TOKEN_VALID_MILISECOND);
+    }
+
+    private String createToken(User user, long expirationMilisecond) {
+        Claims claims = Jwts.claims().setSubject(user.getIdentifier()); // claim 임의로 설정
+        claims.put("username", user.getUsername());
+        Date now = dateFactory.now();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expirationMilisecond))
+                .signWith(SignatureAlgorithm.HS512, secretKey)
+                .compact();
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtResolver.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtResolver.java
@@ -1,0 +1,51 @@
+package kr.co.knowledgerally.api.core.jwt.component;
+
+import io.jsonwebtoken.Jwts;
+import kr.co.knowledgerally.api.core.util.AuthenticationHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
+
+/**
+ * 분석기
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtResolver {
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    private final UserDetailsService userDetailsService;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    /**
+     * JWT token으로부터 인증 정보를 가져옴
+     * @param token jwt 토큰
+     * @return 인증 정보
+     */
+    public Authentication getAuthentication(String token){
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserIdentifier(token));
+        return AuthenticationHelper.getUserPassAuthentication(userDetails);
+    }
+
+    public String getUserIdentifier(String token){
+        return Jwts.parser().setSigningKey(secretKey)
+                .parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        return request.getHeader("X-AUTH-TOKEN");
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtValidator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtValidator.java
@@ -1,0 +1,55 @@
+package kr.co.knowledgerally.api.core.jwt.component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import kr.co.knowledgerally.core.core.component.DateFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * JWT 검증기
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtValidator {
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    private final DateFactory dateFactory;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    /**
+     * jwt 토큰을 검증합니다.
+     * @param jwtToken jwt 토큰
+     * @return 검증 유효시 참, 아닐 시 거짓
+     */
+    public boolean validateToken(String jwtToken){
+        return validateTokenBefore(jwtToken, dateFactory.now());
+    }
+
+    /**
+     * jwt 토큰을 검증합니다.
+     * @param jwtToken jwt 토큰
+     * @param date 검증 기준 날짜
+     * @return 검증 유효시 참, 아닐 시 거짓
+     */
+    public boolean validateTokenBefore(String jwtToken, Date date){
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
+            return !claims.getBody().getExpiration().before(date);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/dto/JwtToken.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/dto/JwtToken.java
@@ -1,0 +1,29 @@
+package kr.co.knowledgerally.api.core.jwt.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ApiModel(value="Knowlly Jwt Token Dto", description="Knowlly 제공 JWT 및 Refresh 토큰 모델")
+public class JwtToken {
+    @ApiModelProperty(value = "Knowlly 제공 Access Token (jwt)")
+    private String knowllyAccessToken;
+
+    @ApiModelProperty(value = "Knowlly 제공 Refresh Token (jwt)")
+    private String knowllyRefreshToken;
+
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    @ApiModel(value="Knowlly Refresh Token Dto", description="Knowlly 제공 Refresh 토큰 모델")
+    public static class Refresh {
+        @ApiModelProperty(value = "Mureng 제공 Refresh Token (jwt)")
+        private String knowllyRefreshToken;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/dto/ProviderToken.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/dto/ProviderToken.java
@@ -1,0 +1,23 @@
+package kr.co.knowledgerally.api.core.jwt.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ApiModel(value="Provider Token Dto", description="Provider 토큰 모델")
+public class ProviderToken {
+    @ApiModelProperty(value = "프로바이더 이름 (현재는 KAKAO만 가능)")
+    private TokenProvider providerName;
+
+    @ApiModelProperty(value = "Provider 제공 Access Token")
+    private String providerAccessToken;
+
+    public void setProviderName(String providerName) {
+        this.providerName = TokenProvider.create(providerName);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/dto/TokenProvider.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/dto/TokenProvider.java
@@ -1,0 +1,25 @@
+package kr.co.knowledgerally.api.core.jwt.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import kr.co.knowledgerally.core.core.exception.BadRequestException;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+import java.util.stream.Stream;
+
+@Getter
+public enum TokenProvider {
+    KAKAO;
+
+    @JsonCreator
+    public static TokenProvider create(String requestValue) {
+        if (! StringUtils.hasLength(requestValue)) {
+            return TokenProvider.KAKAO;
+        }
+
+        return Stream.of(values())
+                .filter(v -> v.toString().equalsIgnoreCase(requestValue))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException("잘못된 프로바이더입니다."));
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/service/JwtService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/service/JwtService.java
@@ -50,7 +50,7 @@ public class JwtService {
      * @param knowllyRefreshToken 리프레시 JWT 토큰
      * @return jwt 토큰
      */
-    @Transactional
+    @Transactional // TODO db 데이터와 대조하는 로직 필요
     public JwtToken refresh(JwtToken.Refresh knowllyRefreshToken){
         if (isExpired(knowllyRefreshToken)) {
             throw new UnauthorizedException("Refresh Token이 만료되었습니다. 다시 로그인 해주세요.");

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/service/JwtService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/service/JwtService.java
@@ -1,0 +1,80 @@
+package kr.co.knowledgerally.api.core.jwt.service;
+
+import kr.co.knowledgerally.api.core.jwt.component.JwtCreator;
+import kr.co.knowledgerally.api.core.jwt.component.JwtResolver;
+import kr.co.knowledgerally.api.core.jwt.component.JwtValidator;
+import kr.co.knowledgerally.api.core.jwt.dto.JwtToken;
+import kr.co.knowledgerally.api.core.jwt.dto.ProviderToken;
+import kr.co.knowledgerally.api.core.oauth2.service.OAuth2ServiceFactory;
+import kr.co.knowledgerally.core.core.component.DateFactory;
+import kr.co.knowledgerally.core.core.exception.UnauthorizedException;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * JWT 관련 로직 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+    private final JwtCreator jwtCreator;
+    private final JwtResolver jwtResolver;
+    private final JwtValidator jwtValidator;
+    private final OAuth2ServiceFactory oAuth2ServiceFactory;
+    private final UserService userService;
+    private final DateFactory dateFactory;
+
+    /**
+     * JWT 토큰 발급
+     * @param providerToken 프로바이더에서 제공하는 토큰 정보
+     * @return jwt 토큰
+     */
+    @Transactional
+    public JwtToken issue(ProviderToken providerToken){
+        String identifier = oAuth2ServiceFactory.getInstance(providerToken.getProviderName()).getProfile(providerToken.getProviderAccessToken()).getIdentifier();
+        User user = userService.findByIdentifier(identifier);
+
+        String accessToken = jwtCreator.createAccessToken(user);
+        String refreshToken = jwtCreator.createRefreshToken(user);
+        return new JwtToken(accessToken, refreshToken);
+    }
+
+    /**
+     * JWT 리프레시 토큰 발급
+     * @param knowllyRefreshToken 리프레시 JWT 토큰
+     * @return jwt 토큰
+     */
+    @Transactional
+    public JwtToken refresh(JwtToken.Refresh knowllyRefreshToken){
+        if (isExpired(knowllyRefreshToken)) {
+            throw new UnauthorizedException("Refresh Token이 만료되었습니다. 다시 로그인 해주세요.");
+        }
+
+        String identifier = jwtResolver.getUserIdentifier(knowllyRefreshToken.getKnowllyRefreshToken());
+        User user = userService.findByIdentifier(identifier);
+
+        String accessToken = jwtCreator.createAccessToken(user);
+        String refreshToken = knowllyRefreshToken.getKnowllyRefreshToken();
+        if (isRefreshable(knowllyRefreshToken)) {
+            refreshToken = jwtCreator.createRefreshToken(user);
+        }
+
+        return new JwtToken(accessToken, refreshToken);
+    }
+
+    private boolean isExpired(JwtToken.Refresh knowllyRefreshToken) {
+        return ! jwtValidator.validateToken(knowllyRefreshToken.getKnowllyRefreshToken());
+    }
+
+    private boolean isRefreshable(JwtToken.Refresh knowllyRefreshToken) {
+        // 유효기간이 1달 이내로 남았다면 리프레시 대상
+        Date datePlusOneMonth = dateFactory.addFromNow(Calendar.MONTH, 1);
+        return ! jwtValidator.validateTokenBefore(knowllyRefreshToken.getKnowllyRefreshToken(), datePlusOneMonth);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/dto/OAuth2Profile.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/dto/OAuth2Profile.java
@@ -1,0 +1,18 @@
+package kr.co.knowledgerally.api.core.oauth2.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Builder
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value="OAuth Profile", description="OAuth Profile 모델")
+public class OAuth2Profile {
+    @ApiModelProperty(value = "사용자 id")
+    private String identifier;
+
+    @ApiModelProperty(value = "사용자 이름")
+    private String name;
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/dto/UserDetailsImpl.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/dto/UserDetailsImpl.java
@@ -1,4 +1,4 @@
-package kr.co.knowledgerally.api.core.service;
+package kr.co.knowledgerally.api.core.oauth2.dto;
 
 import kr.co.knowledgerally.core.user.entity.User;
 import lombok.Getter;

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/service/KakaoOAuth2Service.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/service/KakaoOAuth2Service.java
@@ -23,6 +23,7 @@ import org.springframework.web.client.RestTemplate;
 @Service("kakaoOAuth2Service")
 public class KakaoOAuth2Service implements OAuth2Service {
     private static final String SOCIAL_KAKAO_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String KAKAO_IDENTIFIER_PREFIX = "kakao_";
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
@@ -63,6 +64,6 @@ public class KakaoOAuth2Service implements OAuth2Service {
         long identifier = jsonNode.get("id").asLong();
         String name = jsonNode.get("kakao_account").get("profile").get("nickname").asText();
 
-        return new OAuth2Profile("kakao_" + identifier, name);
+        return new OAuth2Profile(KAKAO_IDENTIFIER_PREFIX + identifier, name);
     }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/service/KakaoOAuth2Service.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/service/KakaoOAuth2Service.java
@@ -1,0 +1,68 @@
+package kr.co.knowledgerally.api.core.oauth2.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.knowledgerally.api.core.oauth2.dto.OAuth2Profile;
+import kr.co.knowledgerally.core.core.exception.KnowllyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 카카오 OAuth2로부터 조회할 수 있는 서비스
+ */
+@RequiredArgsConstructor
+@Service("kakaoOAuth2Service")
+public class KakaoOAuth2Service implements OAuth2Service {
+    private static final String SOCIAL_KAKAO_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 프로바이더로부터 {@link OAuth2Profile}를 조회한다.
+     * @param providerAccessToken 프로바이더 제공 토큰
+     * @return 프로바이더에서 가져온 사용자 프로필
+     */
+    public OAuth2Profile getProfile(String providerAccessToken) {
+        JsonNode profileJson = fetchProfileInfoFromProvider(providerAccessToken);
+        return buildKakaoProfile(profileJson);
+    }
+
+    private JsonNode fetchProfileInfoFromProvider(String providerAccessToken) throws HttpClientErrorException {
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                SOCIAL_KAKAO_PROFILE_URL,
+                buildRequest(providerAccessToken),
+                String.class
+        );
+
+        try {
+            return objectMapper.readTree(response.getBody());
+        } catch (JsonProcessingException e) {
+            throw new KnowllyException("Provider 응답 호출 중 예외 발생", e);
+        }
+    }
+
+    private HttpEntity<?> buildRequest(String providerAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setBearerAuth(providerAccessToken);
+
+        return new HttpEntity<>(null, headers);
+    }
+
+    private OAuth2Profile buildKakaoProfile(JsonNode jsonNode) {
+        long identifier = jsonNode.get("id").asLong();
+        String name = jsonNode.get("kakao_account").get("profile").get("nickname").asText();
+
+        return new OAuth2Profile("kakao_" + identifier, name);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/service/OAuth2Service.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/service/OAuth2Service.java
@@ -1,0 +1,15 @@
+package kr.co.knowledgerally.api.core.oauth2.service;
+
+import kr.co.knowledgerally.api.core.oauth2.dto.OAuth2Profile;
+
+/**
+ * {@link OAuth2Profile}을 조회할 수 있는 서비스
+ */
+public interface OAuth2Service {
+    /**
+     * 프로바이더로부터 {@link OAuth2Profile}를 조회한다.
+     * @param providerAccessToken 프로바이더 제공 토큰
+     * @return 프로바이더에서 가져온 사용자 프로필
+     */
+    OAuth2Profile getProfile(String providerAccessToken);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/service/OAuth2ServiceFactory.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/oauth2/service/OAuth2ServiceFactory.java
@@ -1,0 +1,31 @@
+package kr.co.knowledgerally.api.core.oauth2.service;
+
+import kr.co.knowledgerally.api.core.jwt.dto.TokenProvider;
+import kr.co.knowledgerally.core.core.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+/**
+ * {@link OAuth2Service} 팩토리 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class OAuth2ServiceFactory {
+    @Resource(name = "kakaoOAuth2Service")
+    private final OAuth2Service kakaoOAuth2Service;
+
+    /**
+     * Provider 명에 따라서 {@link OAuth2Service} 구현 클래스를 리턴합니다.
+     * @param provider OAuth2 프로바이더 enum, 현재는 KAKAO만 지원합니다.
+     * @return {@link OAuth2Service} 구현 클래스
+     * @throws BadRequestException provider명이 유효하지 않거나, 구현되어 있지 않으면 던집니다.
+     */
+    public OAuth2Service getInstance(TokenProvider provider) throws BadRequestException {
+        if (provider == TokenProvider.KAKAO) {
+            return kakaoOAuth2Service;
+        }
+        throw new BadRequestException("잘못된 provider 입니다.");
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/service/UserDetailsImpl.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/service/UserDetailsImpl.java
@@ -1,0 +1,59 @@
+package kr.co.knowledgerally.api.core.service;
+
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class UserDetailsImpl implements UserDetails {
+    @Getter
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getIdentifier();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/service/UserDetailsServiceImpl.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/service/UserDetailsServiceImpl.java
@@ -1,0 +1,26 @@
+package kr.co.knowledgerally.api.core.service;
+
+import kr.co.knowledgerally.api.core.oauth2.dto.UserDetailsImpl;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service("userDetailsService")
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserService userService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String identifier) throws UsernameNotFoundException {
+        User user = userService.findByIdentifier(identifier);
+
+        return new UserDetailsImpl(user);
+    }
+}
+

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/util/AuthenticationHelper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/util/AuthenticationHelper.java
@@ -1,0 +1,13 @@
+package kr.co.knowledgerally.api.core.util;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class AuthenticationHelper {
+    private AuthenticationHelper() { }
+
+    public static Authentication getUserPassAuthentication(UserDetails userDetails) {
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/DateStringValidator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/DateStringValidator.java
@@ -1,0 +1,22 @@
+package kr.co.knowledgerally.api.core.validation;
+
+import kr.co.knowledgerally.api.core.validation.annotation.DateFormat;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+
+/**
+ * yyyy-mm-dd 형태의 문자열 유효성 검증
+ */
+public class DateStringValidator implements ConstraintValidator<DateFormat, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        try {
+            LocalDate.parse(value);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/KorEngOnlyValidator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/KorEngOnlyValidator.java
@@ -1,0 +1,17 @@
+package kr.co.knowledgerally.api.core.validation;
+
+import kr.co.knowledgerally.api.core.validation.annotation.KorEngOnly;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+/**
+ * 한글, 숫자, 영어만 허용한다. 한글의 경우 자음, 모음 만 사용하는건 허용 안함
+ */
+public class KorEngOnlyValidator implements ConstraintValidator<KorEngOnly, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+       return Pattern.matches("^[가-힣0-9a-zA-Z]*$", value);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/TimeStringValidator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/TimeStringValidator.java
@@ -1,0 +1,22 @@
+package kr.co.knowledgerally.api.core.validation;
+
+import kr.co.knowledgerally.api.core.validation.annotation.TimeFormat;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.time.LocalTime;
+
+/**
+ * HH:mm:ss 형태의 문자열을 검증한다.
+ */
+public class TimeStringValidator implements ConstraintValidator<TimeFormat, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        try {
+            LocalTime.parse(value);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/annotation/DateFormat.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/annotation/DateFormat.java
@@ -1,0 +1,24 @@
+package kr.co.knowledgerally.api.core.validation.annotation;
+
+import kr.co.knowledgerally.api.core.validation.DateStringValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = DateStringValidator.class)
+@Documented
+public @interface DateFormat {
+    String message() default "Date format should be like yyyy-MM-dd";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/annotation/KorEngOnly.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/annotation/KorEngOnly.java
@@ -1,0 +1,24 @@
+package kr.co.knowledgerally.api.core.validation.annotation;
+
+import kr.co.knowledgerally.api.core.validation.KorEngOnlyValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = KorEngOnlyValidator.class)
+@Documented
+public @interface KorEngOnly {
+    String message() default "한글, 숫자, 영어만 가능합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/annotation/TimeFormat.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/annotation/TimeFormat.java
@@ -1,0 +1,24 @@
+package kr.co.knowledgerally.api.core.validation.annotation;
+
+import kr.co.knowledgerally.api.core.validation.TimeStringValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = TimeStringValidator.class)
+@Documented
+public @interface TimeFormat {
+    String message() default "Time format should be like hh:mm:ss";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/web/ErrorControllerImpl.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/web/ErrorControllerImpl.java
@@ -1,0 +1,31 @@
+package kr.co.knowledgerally.api.core.web;
+
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+
+@ApiIgnore
+@RestController
+public class ErrorControllerImpl implements ErrorController {
+
+    @RequestMapping("/error")
+    public ResponseEntity<?> error(HttpServletRequest request) {
+        Object statusObj = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        if (statusObj != null) {
+            int statusCode = Integer.parseInt(statusObj.toString());
+            HttpStatus status = HttpStatus.valueOf(statusCode);
+            return ResponseEntity.status(status)
+                    .body(ApiResult.fail(status.name()));
+        }
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResult.fail("Internal Server Error"));
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/web/TestController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/web/TestController.java
@@ -1,12 +1,42 @@
 package kr.co.knowledgerally.api.core.web;
 
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.core.core.exception.KnowllyException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
+/**
+ * 테스트용 컨트롤러
+ */
+@ApiIgnore
 @RestController
+@RequestMapping("/api")
 public class TestController {
-    @GetMapping("/")
-    public String test() {
-        return "It works!";
+    @GetMapping("/test")
+    public ResponseEntity<ApiResult<TestObject>> test() {
+        return ResponseEntity.ok(ApiResult.ok(new TestObject("test is ok!!!")));
+    }
+
+    @GetMapping("/authenticated-test")
+    public ResponseEntity<ApiResult<TestObject>> authenticatedTest() {
+        return ResponseEntity.ok(ApiResult.ok(new TestObject("test is ok!!!")));
+    }
+
+    @GetMapping("/test-failure")
+    public ResponseEntity<ApiResult<TestObject>> testFailure() {
+        throw new KnowllyException("net.mureng.mureng failure");
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    public static class TestObject {
+        private String result;
     }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/component/UserImageMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/component/UserImageMapper.java
@@ -1,0 +1,18 @@
+package kr.co.knowledgerally.api.user.component;
+
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.api.user.dto.UserImageDto;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface UserImageMapper {
+    UserImageDto toDto(UserImage userImage);
+
+    @Mapping(target = "user", source = "user")
+    UserImage toEntity(UserImageDto userImageDto, User user);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/component/UserMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/component/UserMapper.java
@@ -1,0 +1,19 @@
+package kr.co.knowledgerally.api.user.component;
+
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.time.format.DateTimeFormatter;
+
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface UserMapper {
+    @Mapping(target = "isCoach", source = "user.coach")
+    @Mapping(target = "isPushActive", source = "user.pushActive")
+    UserDto.ReadOnly toDto(User user);
+    User toEntity(UserDto userDto);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserDto.java
@@ -1,0 +1,84 @@
+package kr.co.knowledgerally.api.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.api.core.validation.annotation.KorEngOnly;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.Column;
+import javax.validation.constraints.NotBlank;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "사용자 모델", description = "사용자를 나타내는 모델")
+public class UserDto {
+
+    @NotBlank
+    @ApiModelProperty(value = "사용자 이름", required = true, position = PropertyDisplayOrder.USERNAME)
+    @JsonProperty(index = PropertyDisplayOrder.USERNAME)
+    private String username;
+
+    @KorEngOnly
+    @NotBlank
+    @ApiModelProperty(value = "사용자 자기 소개", required = true, position = PropertyDisplayOrder.INTRO)
+    @JsonProperty(index = PropertyDisplayOrder.INTRO)
+    private String intro;
+
+    @ApiModelProperty(value = "사용자 카카오 ID", position = PropertyDisplayOrder.KAKAO_ID)
+    @JsonProperty(index = PropertyDisplayOrder.KAKAO_ID)
+    private String kakaoId;
+
+    @ApiModelProperty(value = "사용자 소개 웹사이트 / 포트폴리오", position = PropertyDisplayOrder.PORTFOLIO)
+    @JsonProperty(index = PropertyDisplayOrder.PORTFOLIO)
+    private String portfolio;
+
+    @NotBlank
+    @ApiModelProperty(value = "사용자 식별값", required = true, position = PropertyDisplayOrder.IDENTIFIER)
+    @JsonProperty(index = PropertyDisplayOrder.IDENTIFIER)
+    private String identifier;
+
+    @SuperBuilder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value = "회원 읽기 모델", description = "읽기 전용 회원 모델")
+    public static class ReadOnly extends UserDto {
+        @ApiModelProperty(value = "회원 고유 아이디", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.ID)
+        @JsonProperty(index = PropertyDisplayOrder.ID)
+        private Long id;
+
+        @ApiModelProperty(value = "볼 토큰 개수", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.BALLCNT)
+        @JsonProperty(index = PropertyDisplayOrder.BALLCNT)
+        private int ballCnt;
+
+        @ApiModelProperty(value = "코치 여부", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.IS_COACH)
+        @JsonProperty(index = PropertyDisplayOrder.IS_COACH)
+        private boolean isCoach;
+
+        @ApiModelProperty(value = "푸시 알림 활성화 여부", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.IS_PUSH_ACTIVE)
+        @JsonProperty(index = PropertyDisplayOrder.IS_PUSH_ACTIVE)
+        private boolean isPushActive;
+    }
+
+    private static class PropertyDisplayOrder {
+        private static final int ID = 0;
+        private static final int USERNAME = 1;
+        private static final int BALLCNT = 2;
+        private static final int INTRO = 3;
+        private static final int KAKAO_ID = 4;
+        private static final int PORTFOLIO = 5;
+        private static final int IDENTIFIER = 6;
+        private static final int IS_COACH = 7;
+        private static final int IS_PUSH_ACTIVE = 8;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserImageDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserImageDto.java
@@ -1,0 +1,25 @@
+package kr.co.knowledgerally.api.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.api.core.validation.annotation.KorEngOnly;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import javax.validation.constraints.NotBlank;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "사용자 프로필 이미지 모델", description = "사용자 프로필 이미지를 나타내는 모델")
+public class UserImageDto {
+    @ApiModelProperty(value = "프로필 이미지 경로")
+    @JsonProperty
+    private String userImgUrl;
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserOnboardDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserOnboardDto.java
@@ -1,0 +1,33 @@
+package kr.co.knowledgerally.api.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "사용자 회원가입 모델", description = "사용자 회원가입용 모델")
+public class UserOnboardDto {
+    @ApiModelProperty(value = "사용자 프로필")
+    @JsonProperty
+    private UserDto user;
+
+    @ApiModelProperty(value = "프로필 이미지")
+    @JsonProperty
+    private UserImageDto userImage;
+
+    @Builder
+    @Getter
+    public static class ReadOnly {
+        @ApiModelProperty(value = "사용자 프로필")
+        @JsonProperty
+        private UserDto.ReadOnly user;
+
+        @ApiModelProperty(value = "프로필 이미지")
+        @JsonProperty
+        private UserImageDto userImage;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserOnboardService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserOnboardService.java
@@ -1,0 +1,49 @@
+package kr.co.knowledgerally.api.user.service;
+
+import kr.co.knowledgerally.api.user.component.UserImageMapper;
+import kr.co.knowledgerally.api.user.component.UserMapper;
+import kr.co.knowledgerally.api.user.dto.UserOnboardDto;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.service.UserImageService;
+import kr.co.knowledgerally.core.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+
+/**
+ * 사용자 온보딩 서비스
+ */
+@Validated
+@Service
+@RequiredArgsConstructor
+public class UserOnboardService {
+    private final UserService userService;
+    private final UserImageService userImageService;
+    private final UserMapper userMapper;
+    private final UserImageMapper userImageMapper;
+
+    /**
+     * 사용자 온보딩 서비스
+     * @param userOnboardDto 유저 온보딩 정보
+     * @param loggedInUser 현재 세션 로그인 유저
+     * @return 온보딩 저장 결과 리턴
+     */
+    @Transactional
+    public UserOnboardDto.ReadOnly onBoard(@Valid UserOnboardDto userOnboardDto,
+                                           User loggedInUser) {
+        User onBoardingUser = userMapper.toEntity(userOnboardDto.getUser());
+        onBoardingUser.setId(loggedInUser.getId());
+        User savedUser = userService.saveUser(onBoardingUser);
+        UserImage savedUserImage = userImageService.saveUserImage(userImageMapper.toEntity(userOnboardDto.getUserImage(), savedUser));
+
+        return UserOnboardDto.ReadOnly.builder()
+                .user(userMapper.toDto(savedUser))
+                .userImage(userImageMapper.toDto(savedUserImage))
+                .build();
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserSignUpService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserSignUpService.java
@@ -1,0 +1,52 @@
+package kr.co.knowledgerally.api.user.service;
+
+import kr.co.knowledgerally.api.core.jwt.dto.JwtToken;
+import kr.co.knowledgerally.api.core.jwt.dto.ProviderToken;
+import kr.co.knowledgerally.api.core.jwt.service.JwtService;
+import kr.co.knowledgerally.api.core.oauth2.dto.OAuth2Profile;
+import kr.co.knowledgerally.api.core.oauth2.service.OAuth2ServiceFactory;
+import kr.co.knowledgerally.core.core.exception.BadRequestException;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+
+/**
+ * 사용자 등록 서비스
+ */
+@Validated
+@Service
+@RequiredArgsConstructor
+public class UserSignUpService {
+    private final UserService userService;
+    private final OAuth2ServiceFactory oAuth2ServiceFactory;
+    private final JwtService jwtService;
+
+    /**
+     * 사용자 등록
+     * @param providerToken 프로바이더에서 제공하는 토큰 정보
+     * @return jwt 토큰
+     */
+    @Transactional
+    public JwtToken signUp(@Valid ProviderToken providerToken) {
+        OAuth2Profile oAuth2Profile = oAuth2ServiceFactory.getInstance(providerToken.getProviderName())
+                .getProfile(providerToken.getProviderAccessToken());
+
+        if (userService.isMemberExistByIdentifier(oAuth2Profile.getIdentifier())) {
+            throw new BadRequestException("사용자가 이미 존재합니다.");
+        }
+
+        userService.saveUser(User.builder()
+                        .username(oAuth2Profile.getName())
+                        .identifier(oAuth2Profile.getIdentifier())
+                .build());
+
+        // TODO 후처리 추가 (볼 지급 등)
+
+        return jwtService.issue(providerToken);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserAuthController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserAuthController.java
@@ -48,22 +48,6 @@ public class UserAuthController {
         ));
     }
 
-    @ApiOperation(value = "사용자 식별자 조회", notes = "프로바이더 토큰을 이용해 사용자 식별값을 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "조회 성공"),
-    })
-    @GetMapping("/identifier")
-    public ResponseEntity<ApiResult<UserIdentifierDto>> identifier(
-            @ApiParam(value = "프로바이더 제공 액세스 토큰", required = true)
-            @RequestParam(name = "provider_token") String providerToken,
-            @ApiParam(value = "프로바이더 이름 (현재는 KAKAO만 가능) (생략가능)")
-            @RequestParam(name = "provider_name", required = false, defaultValue = "KAKAO") String providerName) {
-        OAuth2Profile profile = oAuth2ServiceFactory.getInstance(TokenProvider.valueOf(providerName)).getProfile(providerToken);
-        return ResponseEntity.ok(ApiResult.ok(
-                new UserIdentifierDto(profile.getIdentifier())
-        ));
-    }
-
     @ApiOperation(value = "사용자 등록 (JWT 발급)", notes = "사용자를 신규로 등록하고, JWT를 발급합니다.")
     @ApiResponses({
             @ApiResponse(code = 200, message = "등록 성공"),
@@ -103,12 +87,5 @@ public class UserAuthController {
     @Getter
     public static class UserExistsDto {
         private final boolean exists;
-    }
-
-    @ApiIgnore
-    @AllArgsConstructor
-    @Getter
-    public static class UserIdentifierDto {
-        private final String identifier;
     }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserAuthController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserAuthController.java
@@ -1,0 +1,114 @@
+package kr.co.knowledgerally.api.user.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.core.jwt.dto.JwtToken;
+import kr.co.knowledgerally.api.core.jwt.dto.ProviderToken;
+import kr.co.knowledgerally.api.core.jwt.dto.TokenProvider;
+import kr.co.knowledgerally.api.core.jwt.service.JwtService;
+import kr.co.knowledgerally.api.core.oauth2.dto.OAuth2Profile;
+import kr.co.knowledgerally.api.core.oauth2.service.OAuth2ServiceFactory;
+import kr.co.knowledgerally.api.user.service.UserSignUpService;
+import kr.co.knowledgerally.core.user.service.UserService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+
+/**
+ * 회원 인증 관련 엔드포인트
+ */
+@Api(value = "회원 인증 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserAuthController {
+    private final OAuth2ServiceFactory oAuth2ServiceFactory;
+    private final JwtService jwtService;
+    private final UserService userService;
+    private final UserSignUpService signUpService;
+
+    @ApiOperation(value = "사용자 존재 체크", notes = "기존에 있던 사용자인지 체크합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "조회 성공"),
+    })
+    @GetMapping("/user-exists")
+    public ResponseEntity<ApiResult<UserExistsDto>> userExists(
+            @ApiParam(value = "프로바이더 제공 액세스 토큰", required = true)
+            @RequestParam(name = "provider_token") String providerToken,
+            @ApiParam(value = "프로바이더 이름 (현재는 KAKAO만 가능) (생략가능)")
+            @RequestParam(name = "provider_name", required = false, defaultValue = "KAKAO") String providerName) {
+        OAuth2Profile profile = oAuth2ServiceFactory.getInstance(TokenProvider.valueOf(providerName)).getProfile(providerToken);
+        return ResponseEntity.ok(ApiResult.ok(
+                new UserExistsDto(userService.isMemberExistByIdentifier(profile.getIdentifier()))
+        ));
+    }
+
+    @ApiOperation(value = "사용자 식별자 조회", notes = "프로바이더 토큰을 이용해 사용자 식별값을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "조회 성공"),
+    })
+    @GetMapping("/identifier")
+    public ResponseEntity<ApiResult<UserIdentifierDto>> identifier(
+            @ApiParam(value = "프로바이더 제공 액세스 토큰", required = true)
+            @RequestParam(name = "provider_token") String providerToken,
+            @ApiParam(value = "프로바이더 이름 (현재는 KAKAO만 가능) (생략가능)")
+            @RequestParam(name = "provider_name", required = false, defaultValue = "KAKAO") String providerName) {
+        OAuth2Profile profile = oAuth2ServiceFactory.getInstance(TokenProvider.valueOf(providerName)).getProfile(providerToken);
+        return ResponseEntity.ok(ApiResult.ok(
+                new UserIdentifierDto(profile.getIdentifier())
+        ));
+    }
+
+    @ApiOperation(value = "사용자 등록 (JWT 발급)", notes = "사용자를 신규로 등록하고, JWT를 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "등록 성공"),
+            @ApiResponse(code = 400, message = "잘못된 요청, 이미 등록한 사용자"),
+    })
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResult<JwtToken>> signup(
+            @ApiParam(value = "액세스 토큰", required = true) @RequestBody @Valid ProviderToken providerToken) {
+        return ResponseEntity.ok(ApiResult.ok(
+                signUpService.signUp(providerToken)));
+    }
+
+    @ApiOperation(value = "사용자 로그인 (JWT 발급)", notes = "사용자에게 JWT를 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "발급 성공"),
+    })
+    @PostMapping("/signin")
+    public ResponseEntity<ApiResult<JwtToken>> signin(
+            @ApiParam(value = "액세스 토큰", required = true) @RequestBody @Valid ProviderToken providerToken) {
+        return ResponseEntity.ok(ApiResult.ok(
+                jwtService.issue(providerToken)));
+    }
+
+    @ApiOperation(value = "JWT 발급 새로 고침", notes = "refreshToken을 사용하여 JWT를 새로고침 합니다")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "발급 성공")
+    })
+    @GetMapping("/refresh")
+    public ResponseEntity<ApiResult<JwtToken>> refresh(
+            @ApiParam(value = "프로바이더 제공 액세스 토큰", required = true) @RequestParam(name = "refresh_token") String knowllyRefreshToken) {
+        return ResponseEntity.ok(ApiResult.ok(
+                jwtService.refresh(new JwtToken.Refresh(knowllyRefreshToken))));
+    }
+
+    @ApiIgnore
+    @AllArgsConstructor
+    @Getter
+    public static class UserExistsDto {
+        private final boolean exists;
+    }
+
+    @ApiIgnore
+    @AllArgsConstructor
+    @Getter
+    public static class UserIdentifierDto {
+        private final String identifier;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserController.java
@@ -1,0 +1,37 @@
+package kr.co.knowledgerally.api.user.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.core.annotation.CurrentUser;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.user.dto.UserOnboardDto;
+import kr.co.knowledgerally.api.user.service.UserOnboardService;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+
+/**
+ * 회원 정보 관련 엔드포인트
+ */
+@Api(value = "회원 정보 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+    private final UserOnboardService userOnboardService;
+
+    @ApiOperation(value = "온보딩", notes = "온보딩입니다. 소셜 로그인 사용자의 정보를 업데이트 합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "수정 성공"),
+    })
+    @PatchMapping("/onboard")
+    public ResponseEntity<ApiResult<UserOnboardDto.ReadOnly>> signup(
+            @ApiIgnore @CurrentUser User loggedInUser,
+            @ApiParam(value = "온보딩 회원 정보", required = true)
+            @RequestBody @Valid UserOnboardDto userOnboardDto) {
+        return ResponseEntity.ok(ApiResult.ok(userOnboardService.onBoard(userOnboardDto, loggedInUser)));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/annotation/WithMockKnowllyUser.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/annotation/WithMockKnowllyUser.java
@@ -1,0 +1,13 @@
+package kr.co.knowledgerally.api.annotation;
+
+
+import kr.co.knowledgerally.api.config.WithMockKnowllyUserSecurityContextFactory;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockKnowllyUserSecurityContextFactory.class)
+public @interface WithMockKnowllyUser {
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/config/WithMockKnowllyUserSecurityContextFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/config/WithMockKnowllyUserSecurityContextFactory.java
@@ -1,0 +1,25 @@
+package kr.co.knowledgerally.api.config;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.core.service.UserDetailsImpl;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockKnowllyUserSecurityContextFactory implements WithSecurityContextFactory<WithMockKnowllyUser> {
+    @Override
+    public SecurityContext createSecurityContext(WithMockKnowllyUser customUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        TestUserEntityFactory userEntityFactory = new TestUserEntityFactory();
+
+        UserDetailsImpl principal =
+                new UserDetailsImpl(userEntityFactory.createEntity(1L));
+        Authentication auth =
+                new UsernamePasswordAuthenticationToken(principal, "password", principal.getAuthorities());
+        context.setAuthentication(auth);
+        return context;
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/config/WithMockKnowllyUserSecurityContextFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/config/WithMockKnowllyUserSecurityContextFactory.java
@@ -1,7 +1,7 @@
 package kr.co.knowledgerally.api.config;
 
 import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
-import kr.co.knowledgerally.api.core.service.UserDetailsImpl;
+import kr.co.knowledgerally.api.core.oauth2.dto.UserDetailsImpl;
 import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/component/AbstractJwtTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/component/AbstractJwtTest.java
@@ -1,0 +1,29 @@
+package kr.co.knowledgerally.api.core.jwt.component;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 추상 Jwt 테스트 클래스
+ * 토큰 유효기간을 2080 년과 같이 먼 미래로 설정한 이유는 JWT Claim 파싱 시 유효기간이 지나면 ExpiredJwtException을 발생시키기 때문
+ */
+@ExtendWith(MockitoExtension.class)
+abstract class AbstractJwtTest {
+    protected static final String TEST_SECRET_KEY = "dGVzdEtleQ==";
+
+    /**
+     * 2080-10-21 11:58:30 기준 + 24시간 생성
+     */
+    protected static final String TEST_ACCESS_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpZGVudGlmaWVyMSIsInVzZXJuYW1lI" +
+            "joi7YWM7Iqk7Yq4MSIsImlhdCI6MzQ5NjcwNTExMCwiZXhwIjozNDk2NzkxNTEwfQ.TdqYBCkU2wU4a91d-GFoc2giREt1juhgBObYmF3" +
+            "jXJO1oeTgCglehVt1FHCe8stTw8mNc-_ixeTk_JcOTg6lfw";
+
+    /**
+     * 2080-10-21 11:58:30 기준 + 2달 생성
+     */
+    protected static final String TEST_REFRESH_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpZGVudGlmaWVyMSIsInVzZXJuYW1lI" +
+            "joi7YWM7Iqk7Yq4MSIsImlhdCI6MzQ5NjcwNTExMCwiZXhwIjozNTAxODg5MTEwfQ.y9xemg1_dV94r1Dbd9_C0sJetdmvGO_IkQTl713" +
+            "8T52D6SYFk92Axgdc8uO0FlZOtPbzYooNW6SkkJ9I-BA9YA";
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/component/JwtCreatorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/component/JwtCreatorTest.java
@@ -1,0 +1,45 @@
+package kr.co.knowledgerally.api.core.jwt.component;
+
+import kr.co.knowledgerally.core.core.component.DateFactory;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import liquibase.pro.packaged.T;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class JwtCreatorTest extends AbstractJwtTest {
+    @InjectMocks
+    private JwtCreator jwtCreator;
+
+    @Mock
+    private DateFactory dateFactory;
+
+    private final TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(jwtCreator, "secretKey", TEST_SECRET_KEY);
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Seoul"), Locale.KOREA);
+        calendar.set(2080, Calendar.OCTOBER, 21, 11, 58, 30);
+        when(dateFactory.now()).thenReturn(calendar.getTime());
+    }
+
+    @Test
+    public void 액세스_토큰_생성_테스트() {
+        assertEquals(TEST_ACCESS_TOKEN, jwtCreator.createAccessToken(testUserEntityFactory.createEntity(1L)));;
+    }
+
+    @Test
+    public void 리프레시_토큰_생성_테스트() {
+        assertEquals(TEST_REFRESH_TOKEN, jwtCreator.createRefreshToken(testUserEntityFactory.createEntity(1L)));;
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/component/JwtValidatorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/component/JwtValidatorTest.java
@@ -1,0 +1,65 @@
+package kr.co.knowledgerally.api.core.jwt.component;
+
+import kr.co.knowledgerally.core.core.component.DateFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+class JwtValidatorTest extends AbstractJwtTest {
+    @InjectMocks
+    private JwtValidator jwtValidator;
+
+    @Mock
+    private DateFactory dateFactory;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(jwtValidator, "secretKey", TEST_SECRET_KEY);
+    }
+
+    @Test
+    public void 액세스_토큰_유효_테스트() {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Seoul"), Locale.KOREA);
+        calendar.set(2080, Calendar.OCTOBER, 22, 11, 58, 29); // 생성일은 21일
+        when(dateFactory.now()).thenReturn(calendar.getTime());
+
+        assertTrue(jwtValidator.validateToken(TEST_ACCESS_TOKEN));
+    }
+
+    @Test
+    public void 액세스_토큰_만료_테스트() {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Seoul"), Locale.KOREA);
+        calendar.set(2080, Calendar.OCTOBER, 22, 11, 58, 30);
+        when(dateFactory.now()).thenReturn(calendar.getTime());
+
+        assertFalse(jwtValidator.validateToken(TEST_ACCESS_TOKEN));
+    }
+
+    @Test
+    public void 리프레시_토큰_유효_테스트() {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Seoul"), Locale.KOREA);
+        calendar.set(2080, Calendar.DECEMBER, 20, 11, 58, 29); // 생성일은 10월 21일
+        when(dateFactory.now()).thenReturn(calendar.getTime());
+
+        assertTrue(jwtValidator.validateToken(TEST_REFRESH_TOKEN));
+    }
+
+    @Test
+    public void 리프레시_토큰_만료_테스트() {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Seoul"), Locale.KOREA);
+        calendar.set(2080, Calendar.DECEMBER, 20, 11, 58, 30);
+        when(dateFactory.now()).thenReturn(calendar.getTime());
+
+        assertFalse(jwtValidator.validateToken(TEST_REFRESH_TOKEN));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/service/JwtServiceTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/service/JwtServiceTest.java
@@ -1,0 +1,123 @@
+package kr.co.knowledgerally.api.core.jwt.service;
+
+import kr.co.knowledgerally.api.core.jwt.component.JwtCreator;
+import kr.co.knowledgerally.api.core.jwt.component.JwtResolver;
+import kr.co.knowledgerally.api.core.jwt.component.JwtValidator;
+import kr.co.knowledgerally.api.core.jwt.dto.JwtToken;
+import kr.co.knowledgerally.api.core.jwt.dto.ProviderToken;
+import kr.co.knowledgerally.api.core.jwt.dto.TokenProvider;
+import kr.co.knowledgerally.api.core.oauth2.dto.OAuth2Profile;
+import kr.co.knowledgerally.api.core.oauth2.service.OAuth2ServiceFactory;
+import kr.co.knowledgerally.core.core.component.DateFactory;
+import kr.co.knowledgerally.core.core.exception.UnauthorizedException;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.service.UserService;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtServiceTest {
+    private static final String TEST_PROVIDER_ACCESS_TOKEN = "testProviderToken";
+    private static final String TEST_KNOWLLY_ACCESS_TOKEN = "testKnowllyAccessToken";
+    private static final String TEST_KNOWLLY_REFRESH_TOKEN = "testKnowllyRefreshToken";
+    private static final String TEST_NEW_REFRESH_TOKEN = "testNewRefreshToken";
+    private static final String TEST_EXIST_IDENTIFIER = "identifier1";
+
+    @InjectMocks
+    private JwtService jwtService;
+
+    @Mock
+    private JwtCreator jwtCreator;
+
+    @Mock
+    private JwtResolver jwtResolver;
+
+    @Mock
+    private JwtValidator jwtValidator;
+
+    @Mock
+    private OAuth2ServiceFactory oAuth2ServiceFactory;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private DateFactory dateFactory;
+
+    private final TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = testUserEntityFactory.createEntity(1L);
+    }
+
+    @Test
+    void JWT_토큰_발급_테스트() {
+        when(userService.findByIdentifier(eq(TEST_EXIST_IDENTIFIER))).thenReturn(testUser);
+        when(jwtCreator.createAccessToken(eq(testUser))).thenReturn(TEST_KNOWLLY_ACCESS_TOKEN);
+        when(oAuth2ServiceFactory.getInstance(eq(TokenProvider.KAKAO)))
+                .thenReturn(providerAccessToken -> new OAuth2Profile(TEST_EXIST_IDENTIFIER, "테스트이름"));
+        when(jwtCreator.createRefreshToken(eq(testUser))).thenReturn(TEST_KNOWLLY_REFRESH_TOKEN);
+
+        ProviderToken providerToken = new ProviderToken(TokenProvider.KAKAO, TEST_PROVIDER_ACCESS_TOKEN);
+        JwtToken jwtToken = jwtService.issue(providerToken);
+
+        assertEquals(TEST_KNOWLLY_ACCESS_TOKEN, jwtToken.getKnowllyAccessToken());
+        assertEquals(TEST_KNOWLLY_REFRESH_TOKEN, jwtToken.getKnowllyRefreshToken());
+    }
+
+    @Test
+    void 리프레시_토큰_발급_테스트() {
+        when(userService.findByIdentifier(eq(TEST_EXIST_IDENTIFIER))).thenReturn(testUser);
+        when(jwtCreator.createAccessToken(eq(testUser))).thenReturn(TEST_KNOWLLY_ACCESS_TOKEN);
+        when(jwtValidator.validateToken(eq(TEST_KNOWLLY_REFRESH_TOKEN))).thenReturn(true);
+        when(jwtResolver.getUserIdentifier(eq(TEST_KNOWLLY_REFRESH_TOKEN))).thenReturn(TEST_EXIST_IDENTIFIER);
+        when(jwtValidator.validateTokenBefore(eq(TEST_KNOWLLY_REFRESH_TOKEN), any())).thenReturn(true);
+
+        JwtToken.Refresh refreshToken = new JwtToken.Refresh(TEST_KNOWLLY_REFRESH_TOKEN);
+        JwtToken jwtToken = jwtService.refresh(refreshToken);
+
+        assertEquals(TEST_KNOWLLY_ACCESS_TOKEN, jwtToken.getKnowllyAccessToken());
+        assertEquals(TEST_KNOWLLY_REFRESH_TOKEN, jwtToken.getKnowllyRefreshToken());
+    }
+
+    @Test
+    void 리프레시_토큰_발급_리프레시_테스트() {
+        when(userService.findByIdentifier(eq(TEST_EXIST_IDENTIFIER))).thenReturn(testUser);
+        when(jwtCreator.createAccessToken(eq(testUser))).thenReturn(TEST_KNOWLLY_ACCESS_TOKEN);
+        when(jwtValidator.validateToken(eq(TEST_KNOWLLY_REFRESH_TOKEN))).thenReturn(true);
+        when(jwtResolver.getUserIdentifier(eq(TEST_KNOWLLY_REFRESH_TOKEN))).thenReturn(TEST_EXIST_IDENTIFIER);
+        when(jwtValidator.validateTokenBefore(eq(TEST_KNOWLLY_REFRESH_TOKEN), any())).thenReturn(false);
+        when(jwtCreator.createRefreshToken(eq(testUser))).thenReturn(TEST_NEW_REFRESH_TOKEN);
+
+        JwtToken.Refresh refreshToken = new JwtToken.Refresh(TEST_KNOWLLY_REFRESH_TOKEN);
+        JwtToken jwtToken = jwtService.refresh(refreshToken);
+
+        assertEquals(TEST_KNOWLLY_ACCESS_TOKEN, jwtToken.getKnowllyAccessToken());
+        assertEquals(TEST_NEW_REFRESH_TOKEN, jwtToken.getKnowllyRefreshToken());
+    }
+
+    @Test
+    void 리프레시_토큰_발급_만료_테스트() {
+        when(jwtValidator.validateToken(eq(TEST_KNOWLLY_REFRESH_TOKEN))).thenReturn(false);
+
+        assertThrows(UnauthorizedException.class, () -> {
+            JwtToken.Refresh refreshToken = new JwtToken.Refresh(TEST_KNOWLLY_REFRESH_TOKEN);
+            JwtToken jwtToken = jwtService.refresh(refreshToken);
+
+            assertEquals(TEST_KNOWLLY_ACCESS_TOKEN, jwtToken.getKnowllyAccessToken());
+            assertEquals(TEST_NEW_REFRESH_TOKEN, jwtToken.getKnowllyRefreshToken());
+        });
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/oauth2/service/KakaoOAuth2ServiceTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/oauth2/service/KakaoOAuth2ServiceTest.java
@@ -1,0 +1,56 @@
+package kr.co.knowledgerally.api.core.oauth2.service;
+
+import kr.co.knowledgerally.api.core.oauth2.dto.OAuth2Profile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.Resource;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class KakaoOAuth2ServiceTest {
+    private static final String SOCIAL_KAKAO_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String TEST_PROVIDER_ACCESS_TOKEN = "testProviderToken";
+    private static final String TEST_KAKAO_ID = "123456789";
+    private static final String TEST_KAKAO_NICKNAME = "홍길동";
+
+    @Autowired
+    @Resource(name = "kakaoOAuth2Service")
+    OAuth2Service kakaoOAuth2Service;
+
+    @MockBean
+    RestTemplate restTemplate;
+
+    @BeforeEach
+    void setUp() {
+        final String mockKakaoResponse = String.format(
+                "{\n" +
+                "    \"id\":%s,\n" +
+                "    \"kakao_account\": { \n" +
+                "        \"profile\": {\n" +
+                "            \"nickname\": \"%s\"\n" +
+                "        }\n" +
+                "    }  \n" +
+                "}", TEST_KAKAO_ID, TEST_KAKAO_NICKNAME);
+        when(restTemplate.postForEntity(eq(SOCIAL_KAKAO_PROFILE_URL), any(), eq(String.class))).thenReturn(
+                ResponseEntity.of(Optional.of(mockKakaoResponse)));
+    }
+
+    @Test
+    void 카카오_프로필_조회_Mock_테스트() {
+        OAuth2Profile oAuth2Profile = kakaoOAuth2Service.getProfile(TEST_PROVIDER_ACCESS_TOKEN);
+        assertEquals("kakao_" + TEST_KAKAO_ID, oAuth2Profile.getIdentifier());
+        assertEquals(TEST_KAKAO_NICKNAME, oAuth2Profile.getName());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/oauth2/service/OAuth2ServiceFactoryTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/oauth2/service/OAuth2ServiceFactoryTest.java
@@ -1,0 +1,28 @@
+package kr.co.knowledgerally.api.core.oauth2.service;
+
+import kr.co.knowledgerally.api.core.jwt.dto.TokenProvider;
+import kr.co.knowledgerally.core.core.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class OAuth2ServiceFactoryTest {
+    @Autowired
+    OAuth2ServiceFactory oAuth2ServiceFactory;
+
+    @Test
+    void 카카오_서비스_가져오기_테스트() {
+        OAuth2Service oAuth2Service = oAuth2ServiceFactory.getInstance(TokenProvider.KAKAO);
+        assertEquals(oAuth2Service.getClass(), KakaoOAuth2Service.class);
+    }
+
+    @Test
+    void 서비스_가져오기_실패_테스트() {
+        assertThrows(BadRequestException.class, () -> {
+            oAuth2ServiceFactory.getInstance(null);
+        });
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/util/TestDtoFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/util/TestDtoFactory.java
@@ -1,0 +1,14 @@
+package kr.co.knowledgerally.api.core.util;
+
+/**
+ * 테스트용 Dto 생성 팩토리 인터페이스
+ * @param <T> 엔티티 클래스 제네릭
+ */
+public interface TestDtoFactory<T> {
+    /**
+     * 테스트용 Dto를 생성한다.
+     * @param id 생성될 Dto Id
+     * @return 생성된 Dto
+     */
+    T createDto(long id);
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/AbstractValidatorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/AbstractValidatorTest.java
@@ -1,0 +1,17 @@
+package kr.co.knowledgerally.api.core.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+public abstract class AbstractValidatorTest {
+    protected Validator validator;
+
+    @BeforeEach
+    public void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/DateStringValidatorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/DateStringValidatorTest.java
@@ -1,0 +1,49 @@
+package kr.co.knowledgerally.api.core.validation;
+
+
+import kr.co.knowledgerally.api.core.validation.annotation.DateFormat;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DateStringValidatorTest extends AbstractValidatorTest {
+    @Test
+    public void 날짜문자열_검증_단순_테스트() {
+        DateStringValidator validator = new DateStringValidator();
+        assertTrue(validator.isValid("2020-10-14", null));
+        assertFalse(validator.isValid("20202-10-14", null));
+        assertFalse(validator.isValid("2020-13-14", null));
+    }
+
+    @Test
+    public void 날짜문자열_검증_심화_테스트() {
+        SimpleDto simpleDto = new SimpleDto("2020-10-14");
+        Set<ConstraintViolation<SimpleDto>> violations = validator.validate(simpleDto);
+        assertTrue(violations.isEmpty());
+
+        simpleDto = new SimpleDto("20202-10-14");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+
+        simpleDto = new SimpleDto("2020-13-14");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+    }
+
+    private static class SimpleDto {
+        SimpleDto(String dateString) {
+            this.dateString = dateString;
+        }
+
+        @DateFormat
+        private final String dateString;
+
+        public String getDateString() {
+            return dateString;
+        }
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/KorEngOnlyValidatorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/KorEngOnlyValidatorTest.java
@@ -1,0 +1,52 @@
+package kr.co.knowledgerally.api.core.validation;
+
+import kr.co.knowledgerally.api.core.validation.annotation.KorEngOnly;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KorEngOnlyValidatorTest extends AbstractValidatorTest {
+    @Test
+    public void 한글영어문자열_검증_단순_테스트() {
+        KorEngOnlyValidator validator = new KorEngOnlyValidator();
+        assertTrue(validator.isValid("한글만된다", null));
+        assertTrue(validator.isValid("canbeenglish", null));
+        assertTrue(validator.isValid("Canbeboth둘다된다", null));
+        assertTrue(validator.isValid("한글english1234", null));
+        assertFalse(validator.isValid("얘는안된다;;", null));
+        assertFalse(validator.isValid("notthistoo~.~", null));
+        assertFalse(validator.isValid("해보니까 공백넣는 것도 안됨", null));
+    }
+
+    @Test
+    public void 한글영어문자열_검증_심화_테스트() {
+        SimpleDto simpleDto = new SimpleDto("한글english1234");
+        Set<ConstraintViolation<SimpleDto>> violations = validator.validate(simpleDto);
+        assertTrue(violations.isEmpty());
+
+        simpleDto = new SimpleDto("얘는 안된다;;");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+
+        simpleDto = new SimpleDto("not this too ~.~");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+    }
+
+    private static class SimpleDto {
+        SimpleDto(String value) {
+            this.value = value;
+        }
+
+        @KorEngOnly
+        private final String value;
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/TimeStringValidatorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/TimeStringValidatorTest.java
@@ -1,0 +1,49 @@
+package kr.co.knowledgerally.api.core.validation;
+
+
+import kr.co.knowledgerally.api.core.validation.annotation.TimeFormat;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TimeStringValidatorTest extends AbstractValidatorTest {
+    @Test
+    public void 시간문자열_검증_단순_테스트() {
+        TimeStringValidator validator = new TimeStringValidator();
+        assertTrue(validator.isValid("11:23:34", null));
+        assertFalse(validator.isValid("111:23:34", null));
+        assertFalse(validator.isValid("23:61:44", null));
+    }
+
+    @Test
+    public void 시간문자열_검증_심화_테스트() {
+        SimpleDto simpleDto = new SimpleDto("11:23:34");
+        Set<ConstraintViolation<SimpleDto>> violations = validator.validate(simpleDto);
+        assertTrue(violations.isEmpty());
+
+        simpleDto = new SimpleDto("111:23:34");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+
+        simpleDto = new SimpleDto("23:61:44");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+    }
+
+    private static class SimpleDto {
+        SimpleDto(String timeString) {
+            this.timeString = timeString;
+        }
+
+        @TimeFormat
+        private final String timeString;
+
+        public String getTimeString() {
+            return timeString;
+        }
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/web/TestControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/web/TestControllerTest.java
@@ -1,0 +1,51 @@
+package kr.co.knowledgerally.api.core.web;
+
+import kr.co.knowledgerally.api.core.jwt.dto.TokenProvider;
+import kr.co.knowledgerally.api.core.oauth2.dto.OAuth2Profile;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class TestControllerTest extends AbstractControllerTest {
+    private static final String API_TEST_URL = "/api/test";
+    private static final String API_AUTHENTICATED_TEST_URL = "/api/authenticated-test";
+
+    private static final String X_AUTH_TOKEN = "X-AUTH-TOKEN";
+    private static final String TEST_ACCESS_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpZGVudGlmaWVyMSIsInVzZXJuYW1lIjoi" +
+            "7YWM7Iqk7Yq4MSIsImlhdCI6MzQ5NjcwNTExMCwiZXhwIjozNDk2NzkxNTEwfQ.GDahW4oCvj6eu_Nj6_-XAEE4gHmwJaoucqFmHtAZ9U" +
+            "w76MzW3hxz3P8BA6itIuAj0Q6d3gl59iY2CUSot3x8-g";
+
+    private static final String TEST_NOT_VALID_ACCESS_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJub24tZXhpc3QtaWRlbnRpZm" +
+            "llciIsInVzZXJuYW1lIjoi7YWM7Iqk7Yq4MSIsImlhdCI6MzQ5NjcwNTExMCwiZXhwIjozNDk2NzkxNTEwfQ.mE1-xQ5Yr1Txkqz9d1_2" +
+            "wM5fC6KgFLQssALKe7c8lN7qivYHkMGXN21pFzJt_W8977QrpvGodMYK0Q1VtsQBgA";
+
+
+    @Test
+    void JWT_토큰_테스트() throws Exception {
+        mockMvc.perform(
+                        get(API_AUTHENTICATED_TEST_URL)
+                                .header(X_AUTH_TOKEN, TEST_ACCESS_TOKEN)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andDo(print());
+    }
+
+    @Test
+    void JWT_유효하지않은_토큰_테스트() throws Exception {
+        mockMvc.perform(
+                        get(API_AUTHENTICATED_TEST_URL)
+                                .header(X_AUTH_TOKEN, TEST_NOT_VALID_ACCESS_TOKEN)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isUnauthorized())
+                .andDo(print());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/UserImageMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/UserImageMapperTest.java
@@ -1,0 +1,43 @@
+package kr.co.knowledgerally.api.user.component;
+
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.api.user.dto.UserImageDto;
+import kr.co.knowledgerally.api.user.util.TestUserDtoFactory;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import kr.co.knowledgerally.core.user.util.TestUserImageEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserImageMapperTest {
+    @Autowired
+    UserImageMapper userImageMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        UserImage userImage = new TestUserImageEntityFactory().createEntity(1L);
+
+        UserImageDto userImageDto = userImageMapper.toDto(userImage);
+        assertEquals("http://test1.userimg.url", userImageDto.getUserImgUrl());
+    }
+
+    @Test
+    void DTO에서_엔티티변환_테스트() {
+        UserImageDto userImageDto = new UserImageDto("http://test1.userimg.url");
+        User user = new TestUserEntityFactory().createEntity(1L);
+
+        UserImage userImage = userImageMapper.toEntity(userImageDto, user);
+        assertEquals("http://test1.userimg.url", userImage.getUserImgUrl());
+        assertEquals(1L, userImage.getUser().getId());
+        assertEquals("테스트1", userImage.getUser().getUsername());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", userImage.getUser().getIntro());
+        assertEquals("kakao_test1", userImage.getUser().getKakaoId());
+        assertEquals("포트폴리오1", userImage.getUser().getPortfolio());
+        assertEquals("identifier1", userImage.getUser().getIdentifier());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/UserMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/UserMapperTest.java
@@ -1,0 +1,48 @@
+package kr.co.knowledgerally.api.user.component;
+
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.api.user.util.TestUserDtoFactory;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import kr.co.knowledgerally.core.user.util.TestUserImageEntityFactory;
+import liquibase.pro.packaged.T;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserMapperTest {
+    @Autowired
+    private UserMapper userMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        User user = new TestUserEntityFactory().createEntity(1L);
+
+        UserDto.ReadOnly userDto = userMapper.toDto(user);
+        assertEquals(1L, userDto.getId());
+        assertEquals("테스트1", userDto.getUsername());
+        assertEquals(1, userDto.getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", userDto.getIntro());
+        assertEquals("kakao_test1", userDto.getKakaoId());
+        assertEquals("포트폴리오1", userDto.getPortfolio());
+        assertEquals("identifier1", userDto.getIdentifier());
+        assertFalse(userDto.isCoach());
+        assertTrue(userDto.isPushActive());
+    }
+
+    @Test
+    void DTO에서_엔티티변환_테스트() {
+        UserDto userDto = new TestUserDtoFactory().createDto(1L);
+
+        User user = userMapper.toEntity(userDto);
+        assertEquals("테스트1", user.getUsername());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", user.getIntro());
+        assertEquals("kakao_test1", user.getKakaoId());
+        assertEquals("포트폴리오1", user.getPortfolio());
+        assertEquals("identifier1", user.getIdentifier());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/util/TestUserDtoFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/util/TestUserDtoFactory.java
@@ -1,0 +1,46 @@
+package kr.co.knowledgerally.api.user.util;
+
+import kr.co.knowledgerally.api.core.util.TestDtoFactory;
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.core.core.util.TestEntityFactory;
+import kr.co.knowledgerally.core.user.entity.User;
+
+/**
+ * 테스트용 사용자 Dto 생성 팩토리
+ */
+public class TestUserDtoFactory implements TestDtoFactory<UserDto> {
+
+    /**
+     * 테스트용 사용자 Dto를 생성한다.
+     *
+     * @param id 생성될 Dto Id
+     * @return 생성된 사용자 Dto
+     */
+    @Override
+    public UserDto createDto(long id) {
+        return UserDto.builder()
+                .username("테스트1")
+                .intro("안녕하세요. 저는 테스트1이라고 합니다.")
+                .kakaoId("kakao_test1")
+                .portfolio("포트폴리오1")
+                .identifier("identifier1")
+                .build();
+    }
+
+    /**
+     * 테스트용 읽기전용 사용자 Dto를 생성한다.
+     *
+     * @param id 생성될 Dto Id
+     * @return 생성된 사용자 Dto
+     */
+    public UserDto.ReadOnly createReadOnlyDto(long id) {
+        return UserDto.ReadOnly.builder()
+                .id(id)
+                .username("테스트1")
+                .intro("안녕하세요. 저는 테스트1이라고 합니다.")
+                .kakaoId("kakao_test1")
+                .portfolio("포트폴리오1")
+                .identifier("identifier1")
+                .build();
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserAuthControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserAuthControllerTest.java
@@ -1,0 +1,126 @@
+package kr.co.knowledgerally.api.user.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.core.jwt.dto.JwtToken;
+import kr.co.knowledgerally.api.core.jwt.dto.ProviderToken;
+import kr.co.knowledgerally.api.core.jwt.dto.TokenProvider;
+import kr.co.knowledgerally.api.core.jwt.service.JwtService;
+import kr.co.knowledgerally.api.core.oauth2.dto.OAuth2Profile;
+import kr.co.knowledgerally.api.core.oauth2.service.OAuth2ServiceFactory;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserAuthControllerTest extends AbstractControllerTest {
+    private static final String TEST_PROVIDER_ACCESS_TOKEN = "testProviderToken";
+    private static final String TEST_KNOWLLY_ACCESS_TOKEN = "testKnowllyAccessToken";
+    private static final String TEST_KNOWLLY_REFRESH_TOKEN = "testKnowllyRefreshToken";
+    private static final String TEST_EXIST_IDENTIFIER = "identifier1";
+    private static final String TEST_NON_EXIST_IDENTIFIER = "non-exist-identifier";
+
+    @MockBean
+    private JwtService jwtService;
+
+    @MockBean
+    private OAuth2ServiceFactory oAuth2ServiceFactory;
+
+    @BeforeEach
+    void setUp() {
+        ProviderToken provider = new ProviderToken(TokenProvider.KAKAO, TEST_PROVIDER_ACCESS_TOKEN);
+        when(jwtService.issue(eq(provider))).thenReturn(
+                new JwtToken(TEST_KNOWLLY_ACCESS_TOKEN, TEST_KNOWLLY_REFRESH_TOKEN));
+
+        JwtToken.Refresh refresh = new JwtToken.Refresh(TEST_KNOWLLY_REFRESH_TOKEN);
+        when(jwtService.refresh(eq(refresh))).thenReturn(
+                new JwtToken(TEST_KNOWLLY_ACCESS_TOKEN, TEST_KNOWLLY_REFRESH_TOKEN));
+    }
+
+    @Test
+    void 사용자_존재체크_테스트() throws Exception {
+        when(oAuth2ServiceFactory.getInstance(eq(TokenProvider.KAKAO)))
+                .thenReturn(providerAccessToken -> new OAuth2Profile(TEST_EXIST_IDENTIFIER, "테스트이름"));
+
+        mockMvc.perform(
+                        get("/api/user/user-exists")
+                                .param("provider_token", TEST_PROVIDER_ACCESS_TOKEN)
+                                .param("provider_name", "KAKAO")
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.exists").value(true))
+                .andDo(print());
+    }
+
+    @Test
+    void 사용자_존재체크_테스트2() throws Exception {
+        when(oAuth2ServiceFactory.getInstance(eq(TokenProvider.KAKAO)))
+                .thenReturn(providerAccessToken -> new OAuth2Profile(TEST_NON_EXIST_IDENTIFIER, "테스트이름"));
+
+        mockMvc.perform(
+                        get("/api/user/user-exists")
+                                .param("provider_token", TEST_PROVIDER_ACCESS_TOKEN)
+                                .param("provider_name", "KAKAO")
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.exists").value(false))
+                .andDo(print());
+    }
+
+    @Test
+    void 사용자_등록_테스트() throws Exception {
+        when(oAuth2ServiceFactory.getInstance(eq(TokenProvider.KAKAO)))
+                .thenReturn(providerAccessToken -> new OAuth2Profile(TEST_NON_EXIST_IDENTIFIER, "테스트이름"));
+
+        String body = String.format("{\"providerName\":\"KAKAO\", " +
+                "\"providerAccessToken\":\"%s\"}", TEST_PROVIDER_ACCESS_TOKEN);
+        mockMvc.perform(
+                        post("/api/user/signup")
+                                .content(body)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.knowllyAccessToken").value(TEST_KNOWLLY_ACCESS_TOKEN))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.knowllyRefreshToken").value(TEST_KNOWLLY_REFRESH_TOKEN))
+                .andDo(print());
+    }
+
+    @Test
+    void 사용자_로그인_테스트() throws Exception {
+        String body = String.format("{\"providerName\":\"KAKAO\", " +
+                "\"providerAccessToken\":\"%s\"}", TEST_PROVIDER_ACCESS_TOKEN);
+        mockMvc.perform(
+                        post("/api/user/signin")
+                                .content(body)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.knowllyAccessToken").value(TEST_KNOWLLY_ACCESS_TOKEN))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.knowllyRefreshToken").value(TEST_KNOWLLY_REFRESH_TOKEN))
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockKnowllyUser
+    void 사용자_리프레시_테스트() throws Exception {
+        mockMvc.perform(
+                        get("/api/user/refresh")
+                                .param("refresh_token", TEST_KNOWLLY_REFRESH_TOKEN)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.knowllyAccessToken").value(TEST_KNOWLLY_ACCESS_TOKEN))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.knowllyRefreshToken").value(TEST_KNOWLLY_REFRESH_TOKEN))
+                .andDo(print());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserControllerTest.java
@@ -12,10 +12,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class UserControllerTest extends AbstractControllerTest {
+    private static final String USER_ONBOARD_URL = "/api/user/onboard";
+
     @WithMockKnowllyUser
     @Test
     public void 사용자_온보딩_테스트() throws Exception {
-        String newMemberJsonString =
+        final String newMemberJsonString =
                 "{" +
                     "\"user\" : {" +
                         "\"username\": \"테스트이름\"," +
@@ -30,7 +32,7 @@ class UserControllerTest extends AbstractControllerTest {
                 "}";
 
         mockMvc.perform(
-                        patch("/api/user/onboard")
+                        patch(USER_ONBOARD_URL)
                                 .content(newMemberJsonString)
                                 .contentType(MediaType.APPLICATION_JSON)
                 ).andExpect(status().isOk())

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserControllerTest.java
@@ -1,0 +1,47 @@
+package kr.co.knowledgerally.api.user.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserControllerTest extends AbstractControllerTest {
+    @WithMockKnowllyUser
+    @Test
+    public void 사용자_온보딩_테스트() throws Exception {
+        String newMemberJsonString =
+                "{" +
+                    "\"user\" : {" +
+                        "\"username\": \"테스트이름\"," +
+                        "\"intro\": \"테스트 자기소개\"," +
+                        "\"kakaoId\": \"test_kakao_id\"," +
+                        "\"portfolio\": \"portfolio.io\"," +
+                        "\"identifier\": \"kakao_12341234\"" +
+                "   }," +
+                    "\"userImage\" : {" +
+                        "\"userImgUrl\": \"http://testImgUrl.com\"" +
+                    "}" +
+                "}";
+
+        mockMvc.perform(
+                        patch("/api/user/onboard")
+                                .content(newMemberJsonString)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.id").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.username").value("테스트이름"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.intro").value("테스트 자기소개"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.kakaoId").value("test_kakao_id"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.portfolio").value("portfolio.io"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.identifier").value("kakao_12341234"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.userImage.userImgUrl").value("http://testImgUrl.com"));
+    }
+
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/web/AbstractControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/web/AbstractControllerTest.java
@@ -1,0 +1,17 @@
+package kr.co.knowledgerally.api.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@Sql("classpath:/sql/integration.sql")
+@AutoConfigureMockMvc
+public abstract class AbstractControllerTest {
+    @Autowired
+    protected MockMvc mockMvc;
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/component/DateFactory.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/component/DateFactory.java
@@ -1,0 +1,29 @@
+package kr.co.knowledgerally.core.core.component;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+@Component
+public class DateFactory {
+    public Date now() {
+        return new Date();
+    }
+
+    /**
+     * 현재 날짜로부터 더한(혹은 뺀) 결과를 리턴
+     * @param field {@link Calendar} 의 상수 필드 (ex: Calendar.MONTH)
+     * @param amount 변동할 양
+     * @return 결과 Date
+     * @see Calendar
+     */
+    public Date addFromNow(int field, int amount) {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Seoul"), Locale.KOREA);
+        calendar.setTime(new Date());
+        calendar.add(field, amount);
+        return calendar.getTime();
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/component/NumberRandomizer.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/component/NumberRandomizer.java
@@ -1,0 +1,20 @@
+package kr.co.knowledgerally.core.core.component;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+public class NumberRandomizer {
+    private final Random rand = new Random();
+
+    /**
+     *  무작위 양의 정수를 구한다.
+     * @param maximum 나올 수 있는 최대 숫자
+     * @return 랜덤 숫자
+     */
+    public int getRandomInt(int maximum) {
+        rand.setSeed(System.currentTimeMillis());
+        return rand.nextInt(maximum) + 1;
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/AccessNotAllowedException.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/AccessNotAllowedException.java
@@ -1,0 +1,25 @@
+package kr.co.knowledgerally.core.core.exception;
+
+/**
+ * 리소스 접근 권한 없음 예외 (403 Forbidden)
+ */
+public class AccessNotAllowedException extends KnowllyException {
+    public AccessNotAllowedException() {
+    }
+
+    public AccessNotAllowedException(String message) {
+        super(message);
+    }
+
+    public AccessNotAllowedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AccessNotAllowedException(Throwable cause) {
+        super(cause);
+    }
+
+    public AccessNotAllowedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/BadRequestException.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/BadRequestException.java
@@ -1,0 +1,25 @@
+package kr.co.knowledgerally.core.core.exception;
+
+/**
+ * 리소스 잘못된 요청 예외 (400 Bad Request)
+ */
+public class BadRequestException extends KnowllyException {
+    public BadRequestException() {
+    }
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BadRequestException(Throwable cause) {
+        super(cause);
+    }
+
+    public BadRequestException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/EntityNotFoundException.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/EntityNotFoundException.java
@@ -1,0 +1,22 @@
+package kr.co.knowledgerally.core.core.exception;
+
+public class EntityNotFoundException extends ResourceNotFoundException {
+    public EntityNotFoundException() {
+    }
+
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+
+    public EntityNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EntityNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public EntityNotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/KnowllyException.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/KnowllyException.java
@@ -1,0 +1,26 @@
+package kr.co.knowledgerally.core.core.exception;
+
+/**
+ * 널리 도메인 비즈니스 예외 (500 Server Error)
+ */
+public class KnowllyException extends RuntimeException {
+
+    public KnowllyException() {
+    }
+
+    public KnowllyException(String message) {
+        super(message);
+    }
+
+    public KnowllyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public KnowllyException(Throwable cause) {
+        super(cause);
+    }
+
+    public KnowllyException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/ResourceNotFoundException.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/ResourceNotFoundException.java
@@ -1,0 +1,25 @@
+package kr.co.knowledgerally.core.core.exception;
+
+/**
+ * 리소스 찾을 수 없음 예외 (404 Not Found)
+ */
+public class ResourceNotFoundException extends KnowllyException {
+    public ResourceNotFoundException() {
+    }
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ResourceNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public ResourceNotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/UnauthorizedException.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/exception/UnauthorizedException.java
@@ -1,0 +1,24 @@
+package kr.co.knowledgerally.core.core.exception;
+/**
+ * 인증되지 않은 접근 예외 (401 NotAuthorized)
+ */
+public class UnauthorizedException extends KnowllyException {
+    public UnauthorizedException() {
+    }
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+
+    public UnauthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnauthorizedException(Throwable cause) {
+        super(cause);
+    }
+
+    public UnauthorizedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ErrorMessage.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ErrorMessage.java
@@ -1,0 +1,12 @@
+package kr.co.knowledgerally.core.core.message;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class ErrorMessage {
+    // Authorization
+    public static String UNAUTHORIZED = "접근 권한이 없습니다.";
+
+    // Member
+    public static String NOT_EXIST_USER = "존재하지 않는 사용자입니다.";
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ResponseMessage.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ResponseMessage.java
@@ -1,0 +1,8 @@
+package kr.co.knowledgerally.core.core.message;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class ResponseMessage {
+    public static String CHECK_BADGE_ACCOMPLISHED = "뱃지 획득을 확인하였습니다.";
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/UserRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/UserRepository.java
@@ -3,5 +3,22 @@ package kr.co.knowledgerally.core.user.repository;
 import kr.co.knowledgerally.core.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    /**
+     * 사용자를 식별자와 활성화 여부로 존재하는지 여부 검색
+     * @param identifier 사용자 식별자
+     * @param isActive 활성화 여부
+     * @return 사용자가 존재하면 true, 그렇지 않다면 false
+     */
+    boolean existsByIdentifierAndIsActive(String identifier, boolean isActive);
+
+    /**
+     * 사용자를 식별자와 활성화 여부로 검색
+     * @param identifier 사용자 식별자
+     * @param isActive 활성화 여부
+     * @return 사용자 Optional
+     */
+    Optional<User> findByIdentifierAndIsActive(String identifier, boolean isActive);
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserImageService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserImageService.java
@@ -1,0 +1,27 @@
+package kr.co.knowledgerally.core.user.service;
+
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.repository.UserImageRepository;
+import kr.co.knowledgerally.core.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+
+import static kr.co.knowledgerally.core.core.message.ErrorMessage.NOT_EXIST_USER;
+
+@Validated
+@Service
+@RequiredArgsConstructor
+public class UserImageService {
+    private final UserImageRepository userImageRepository;
+
+    @Transactional
+    public UserImage saveUserImage(@Valid UserImage newUserImage) {
+        return userImageRepository.saveAndFlush(newUserImage);
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserService.java
@@ -29,8 +29,4 @@ public class UserService {
     @Transactional(readOnly = true)
     public User findByIdentifier(String identifier) { return userRepository.findByIdentifierAndIsActive(identifier, true)
             .orElseThrow(() -> new ResourceNotFoundException(NOT_EXIST_USER)); }
-
-    @Transactional(readOnly = true)
-    public User findById(Long memberId) { return userRepository.findById(memberId)
-            .orElseThrow(() -> new ResourceNotFoundException(NOT_EXIST_USER)); }
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserService.java
@@ -1,0 +1,36 @@
+package kr.co.knowledgerally.core.user.service;
+
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+
+import static kr.co.knowledgerally.core.core.message.ErrorMessage.NOT_EXIST_USER;
+
+@Validated
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User saveUser(@Valid User newUser) {
+        return userRepository.saveAndFlush(newUser);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isMemberExistByIdentifier(String identifier) { return userRepository.existsByIdentifierAndIsActive(identifier, true); }
+
+    @Transactional(readOnly = true)
+    public User findByIdentifier(String identifier) { return userRepository.findByIdentifierAndIsActive(identifier, true)
+            .orElseThrow(() -> new ResourceNotFoundException(NOT_EXIST_USER)); }
+
+    @Transactional(readOnly = true)
+    public User findById(Long memberId) { return userRepository.findById(memberId)
+            .orElseThrow(() -> new ResourceNotFoundException(NOT_EXIST_USER)); }
+}

--- a/knowlly-core/src/main/resources/application.yml
+++ b/knowlly-core/src/main/resources/application.yml
@@ -19,6 +19,9 @@ spring:
     batch:
       job:
         enabled: false
+      # JWT
+    jwt:
+      secret: 12345678901234567890123456789012
 
     mvc:
       pathmatch:

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/UserRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/UserRepositoryTest.java
@@ -1,0 +1,55 @@
+package kr.co.knowledgerally.core.user.repository;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@KnowllyDataTest
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+})
+class UserRepositoryTest {
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    void 식별자로_사용자_존재하는지_테스트() {
+        assertTrue(userRepository.existsByIdentifierAndIsActive("identifier1", true));
+        assertFalse(userRepository.existsByIdentifierAndIsActive("identifier5", true));
+    }
+
+    @Test
+    void 식별자로_사용자_찾기_테스트() {
+        User user = userRepository.findByIdentifierAndIsActive("identifier1", true).orElseThrow();
+
+        assertEquals(1L, user.getId());
+        assertEquals("test1@email.com", user.getEmail());
+        assertEquals("테스트1", user.getUsername());
+        assertEquals(1, user.getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", user.getIntro());
+        assertEquals("kakao_test1", user.getKakaoId());
+        assertEquals("포트폴리오1", user.getPortfolio());
+        assertEquals("identifier1", user.getIdentifier());
+        assertTrue(user.isCoach());
+        assertTrue(user.isPushActive());
+        assertTrue(user.isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 18, 58), user.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 19, 0), user.getUpdatedAt());
+    }
+
+    @Test
+    void 식별자로_비활성_사용자_찾기_테스트() {
+        assertThrows(NoSuchElementException.class, () -> {
+            // 5번 사용자는 비활성화 되어있기 때문에 못 찾아야 함
+            userRepository.findByIdentifierAndIsActive("identifier5", true).orElseThrow();
+        });
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/service/UserImageServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/service/UserImageServiceTest.java
@@ -1,0 +1,34 @@
+package kr.co.knowledgerally.core.user.service;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.ExpectedDatabase;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.util.TestUserImageEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@KnowllyDataTest
+@Import(UserImageService.class)
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/user_image.xml",
+})
+class UserImageServiceTest {
+    @Autowired
+    UserImageService userImageService;
+
+    TestUserImageEntityFactory testUserImageEntityFactory = new TestUserImageEntityFactory();
+
+    @Test
+    @ExpectedDatabase(value = "classpath:dbunit/expected/crud/user_image_insert_test.xml",
+            assertionMode = DatabaseAssertionMode.NON_STRICT)
+    void 유저_이미지_저장_테스트() {
+        UserImage userImage = testUserImageEntityFactory.createEntity(8L, 1L);
+        userImageService.saveUserImage(userImage);
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/service/UserServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/service/UserServiceTest.java
@@ -1,0 +1,68 @@
+package kr.co.knowledgerally.core.user.service;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.ExpectedDatabase;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@KnowllyDataTest
+@Import(UserService.class)
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+})
+class UserServiceTest {
+    @Autowired
+    UserService userService;
+
+    TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
+
+    @Test
+    @ExpectedDatabase(value = "classpath:dbunit/expected/crud/user_insert_test.xml",
+            assertionMode = DatabaseAssertionMode.NON_STRICT)
+    void 사용자_저장_테스트() {
+        User user = testUserEntityFactory.createEntity(6L);
+        userService.saveUser(user);
+    }
+
+    @Test
+    void 식별자로_사용자_존재여부_판별() {
+        assertTrue(userService.isMemberExistByIdentifier("identifier1"));
+        assertFalse(userService.isMemberExistByIdentifier("identifier5"));
+    }
+
+    @Test
+    void 식별자로_사용자_찾기() {
+        User user = userService.findByIdentifier("identifier1");
+
+        assertEquals(1L, user.getId());
+        assertEquals("test1@email.com", user.getEmail());
+        assertEquals("테스트1", user.getUsername());
+        assertEquals(1, user.getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", user.getIntro());
+        assertEquals("kakao_test1", user.getKakaoId());
+        assertEquals("포트폴리오1", user.getPortfolio());
+        assertEquals("identifier1", user.getIdentifier());
+        assertTrue(user.isCoach());
+        assertTrue(user.isPushActive());
+        assertTrue(user.isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 18, 58), user.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 19, 0), user.getUpdatedAt());
+    }
+
+    @Test
+    void 식별자로_사용자_찾기_실패() {
+        assertThrows(ResourceNotFoundException.class, () -> {
+            userService.findByIdentifier("non-exist-identifier");
+        });
+    }
+}

--- a/knowlly-core/src/test/resources/sql/integration.sql
+++ b/knowlly-core/src/test/resources/sql/integration.sql
@@ -1,0 +1,78 @@
+INSERT INTO user (id, username, ball_cnt, intro, is_coach, is_push_active, is_active, created_at, updated_at, kakao_id, portfolio, identifier, email) VALUES (1, '테스트1', 1, '안녕하세요. 저는 테스트1이라고 합니다.', true, true, true, '2022-06-10 21:18:58', '2022-06-10 21:19:00', 'kakao_test1', null, 'identifier1', 'test1@email.com');
+INSERT INTO user (id, username, ball_cnt, intro, is_coach, is_push_active, is_active, created_at, updated_at, kakao_id, portfolio, identifier, email) VALUES (2, '테스트2', 2, '안녕하세요. 저는 테스트2이라고 합니다.', false, true, true, '2022-06-11 21:18:58', '2022-06-12 21:19:00', 'kakao_test2', null, 'identifier2', 'test2@email.com');
+INSERT INTO user (id, username, ball_cnt, intro, is_coach, is_push_active, is_active, created_at, updated_at, kakao_id, portfolio, identifier, email) VALUES (3, '테스트3', 3, '안녕하세요. 저는 테스트3이라고 합니다.', true, false, true, '2022-06-13 21:18:58', '2022-06-13 21:19:00', 'kakao_test3', null, 'identifier3', 'test3@email.com');
+INSERT INTO user (id, username, ball_cnt, intro, is_coach, is_push_active, is_active, created_at, updated_at, kakao_id, portfolio, identifier, email) VALUES (4, '테스트4', 5, '안녕하세요. 저는 테스트4이라고 합니다.', true, true, true, '2022-06-05 21:18:58', '2022-06-11 21:19:00', 'kakao_test4', null, 'identifier4', 'test4@email.com');
+INSERT INTO user (id, username, ball_cnt, intro, is_coach, is_push_active, is_active, created_at, updated_at, kakao_id, portfolio, identifier, email) VALUES (5, '테스트5', 6, '안녕하세요. 저는 테스트5이라고 합니다.', true, true, false, '2022-06-08 21:18:58', '2022-06-10 21:19:00', 'kakao_test5', null, 'identifier5', 'test5@email.com');
+
+INSERT INTO user_image (id, user_id, user_img_url, is_active, created_at, updated_at) VALUES (1, 1, 'http://test1.img.url', true, '2022-06-13 21:26:58', '2022-06-13 21:27:01');
+INSERT INTO user_image (id, user_id, user_img_url, is_active, created_at, updated_at) VALUES (2, 1, 'http://test1.img2.url', false, '2022-06-13 21:26:59', '2022-06-13 21:27:00');
+INSERT INTO user_image (id, user_id, user_img_url, is_active, created_at, updated_at) VALUES (3, 2, 'http://test2.img.url', false, '2022-06-13 21:27:02', '2022-06-13 21:27:01');
+INSERT INTO user_image (id, user_id, user_img_url, is_active, created_at, updated_at) VALUES (4, 3, 'http://test3.img.url', true, '2022-06-13 21:27:03', '2022-06-13 21:27:03');
+INSERT INTO user_image (id, user_id, user_img_url, is_active, created_at, updated_at) VALUES (5, 4, 'http://test4.img.url', true, '2022-06-13 21:27:04', '2022-06-13 21:27:04');
+INSERT INTO user_image (id, user_id, user_img_url, is_active, created_at, updated_at) VALUES (6, 5, 'http://test5.img.url', true, '2022-06-13 21:27:05', '2022-06-13 21:27:05');
+INSERT INTO user_image (id, user_id, user_img_url, is_active, created_at, updated_at) VALUES (7, 2, 'http://test2.img2.url', true, '2022-06-13 21:27:06', '2022-06-13 21:27:06');
+
+INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (1, 1, '운영 클래스', '프랑스어 수업', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (2, 1, '수강 클래스', '영어 수업', -1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (3, 2, '온보딩', '온보딩', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (4, 2, '수강 클래스', '자바 수업', -1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (5, 3, '운영 클래스', '프랑스어 수업', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (6, 4, '온보딩', '온보딩', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (7, 5, '운영 클래스', '프랑스어 수업', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+
+INSERT INTO coach (id, user_id, introduce, is_active, created_at, updated_at) VALUES (1, 1, '안녕하세요. 테스트1 코치입니다.', true, '2022-06-13 21:57:17', '2022-06-13 21:57:17');
+INSERT INTO coach (id, user_id, introduce, is_active, created_at, updated_at) VALUES (2, 3, '안녕하세요. 테스트3 코치입니다.', true, '2022-06-13 21:57:18', '2022-06-13 21:57:18');
+INSERT INTO coach (id, user_id, introduce, is_active, created_at, updated_at) VALUES (3, 4, '안녕하세요. 테스트4 코치입니다.', true, '2022-06-13 21:57:18', '2022-06-13 21:57:19');
+INSERT INTO coach (id, user_id, introduce, is_active, created_at, updated_at) VALUES (4, 5, '안녕하세요. 테스트5 코치입니다.', false, '2022-06-13 21:57:20', '2022-06-13 21:57:19');
+
+INSERT INTO notification (id, user_id, coach_id, content, noti_type, is_read, is_active, created_at, updated_at) VALUES (1, 1, 3, '알림 내용', 'PLAYER', false, true, '2022-06-13 22:17:08', '2022-06-13 22:17:09');
+INSERT INTO notification (id, user_id, coach_id, content, noti_type, is_read, is_active, created_at, updated_at) VALUES (2, 3, 1, '알림 내용2', 'COACH', true, true, '2022-06-13 22:17:08', '2022-06-13 22:17:09');
+INSERT INTO notification (id, user_id, coach_id, content, noti_type, is_read, is_active, created_at, updated_at) VALUES (3, 1, 2, '알림 내용', 'PLAYER', false, true, '2022-06-13 22:17:08', '2022-06-13 22:17:09');
+INSERT INTO notification (id, user_id, coach_id, content, noti_type, is_read, is_active, created_at, updated_at) VALUES (4, 4, 3, '알림 내용', 'PLAYER', true, true, '2022-06-13 22:17:08', '2022-06-13 22:17:09');
+
+INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at) VALUES (1, 1, 3, '테스트3은 좋은 코치입니다!', true, '2022-06-13 22:19:14', '2022-06-13 22:19:15');
+INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at) VALUES (2, 2, 1, '테스트1 코치는 친절했어요~', true, '2022-06-13 22:19:14', '2022-06-13 22:19:15');
+INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at) VALUES (3, 4, 3, '테스트3 코치는 좀 별로였습니다', true, '2022-06-13 22:19:16', '2022-06-13 22:19:16');
+INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at) VALUES (4, 3, 1, '테스트1 코치가 최고에요~', true, '2022-06-13 22:19:18', '2022-06-13 22:19:17');
+
+INSERT INTO category (id, category_name, is_active) VALUES (1, '기획 / PM', true);
+INSERT INTO category (id, category_name, is_active) VALUES (2, '디자인', true);
+INSERT INTO category (id, category_name, is_active) VALUES (3, '개발', true);
+INSERT INTO category (id, category_name, is_active) VALUES (4, '마케팅', true);
+INSERT INTO category (id, category_name, is_active) VALUES (5, '외국어', true);
+INSERT INTO category (id, category_name, is_active) VALUES (6, '기타', true);
+
+INSERT INTO lecture_information (id, coach_id, category_id, topic, introduce, price, is_active, created_at, updated_at) VALUES (1, 1, 4, '마케팅 수업', '효과적인 마케팅에 대해 배웁니다', 1, true, '2022-06-13 22:39:40', '2022-06-13 22:39:54');
+INSERT INTO lecture_information (id, coach_id, category_id, topic, introduce, price, is_active, created_at, updated_at) VALUES (2, 2, 3, '자바 개발', '자바를 자바라', 1, true, '2022-06-13 22:39:41', '2022-06-13 22:39:54');
+INSERT INTO lecture_information (id, coach_id, category_id, topic, introduce, price, is_active, created_at, updated_at) VALUES (3, 3, 2, '그래픽 디자인', '그래픽을 그래그래', 1, true, '2022-06-13 22:39:42', '2022-06-13 22:39:55');
+INSERT INTO lecture_information (id, coach_id, category_id, topic, introduce, price, is_active, created_at, updated_at) VALUES (4, 4, 1, '좋은 기획이란 무엇인가', '기획이 제일 쉬웠어요 사실 뻥이야', 1, false, '2022-06-13 22:39:42', '2022-06-13 22:39:55');
+INSERT INTO lecture_information (id, coach_id, category_id, topic, introduce, price, is_active, created_at, updated_at) VALUES (5, 1, 6, '요리 클래스', '맛있는 요리 만들기', 1, true, '2022-06-13 22:39:42', '2022-06-13 22:39:55');
+
+INSERT INTO lecture (id, lecture_info_id, start_at, end_at, state, is_review_written, is_active, created_at, updated_at) VALUES (1, 1, '2022-06-08 22:44:10', '2022-06-08 23:44:04', 'DONE', true, true, '2022-06-08 22:44:10', '2022-06-08 22:44:10');
+INSERT INTO lecture (id, lecture_info_id, start_at, end_at, state, is_review_written, is_active, created_at, updated_at) VALUES (2, 1, '2022-06-09 22:44:10', '2022-06-09 23:44:04', 'ON_GOING', false, true, '2022-06-08 22:44:10', '2022-06-08 22:44:10');
+INSERT INTO lecture (id, lecture_info_id, start_at, end_at, state, is_review_written, is_active, created_at, updated_at) VALUES (3, 1, '2022-06-10 22:44:10', '2022-06-10 23:44:04', 'ON_BOARD', false, true, '2022-06-08 22:44:10', '2022-06-08 22:44:10');
+INSERT INTO lecture (id, lecture_info_id, start_at, end_at, state, is_review_written, is_active, created_at, updated_at) VALUES (4, 2, '2022-06-12 22:44:10', '2022-06-12 23:44:04', 'ON_BOARD', false, true, '2022-06-08 22:44:10', '2022-06-08 22:44:10');
+INSERT INTO lecture (id, lecture_info_id, start_at, end_at, state, is_review_written, is_active, created_at, updated_at) VALUES (5, 3, '2022-06-08 22:44:10', '2022-06-13 23:44:04', 'DONE', true, true, '2022-06-08 22:44:10', '2022-06-08 22:44:10');
+INSERT INTO lecture (id, lecture_info_id, start_at, end_at, state, is_review_written, is_active, created_at, updated_at) VALUES (6, 4, '2022-06-13 22:44:10', '2022-06-13 23:44:04', 'ON_BOARD', false, true, '2022-06-08 22:44:10', '2022-06-08 22:44:10');
+
+INSERT INTO tag (id, lecture_info_id, content, is_active, created_at, updated_at) VALUES (1, 1, '마케팅', true, '2022-06-13 22:42:23', '2022-06-13 22:42:23');
+INSERT INTO tag (id, lecture_info_id, content, is_active, created_at, updated_at) VALUES (2, 1, '쉬워요', true, '2022-06-13 22:42:24', '2022-06-13 22:42:24');
+INSERT INTO tag (id, lecture_info_id, content, is_active, created_at, updated_at) VALUES (3, 2, '언어', true, '2022-06-13 22:42:25', '2022-06-13 22:42:25');
+INSERT INTO tag (id, lecture_info_id, content, is_active, created_at, updated_at) VALUES (4, 2, '자바개발', true, '2022-06-13 22:42:26', '2022-06-13 22:42:26');
+INSERT INTO tag (id, lecture_info_id, content, is_active, created_at, updated_at) VALUES (5, 3, '전문가', false, '2022-06-13 22:42:27', '2022-06-13 22:42:27');
+
+INSERT INTO lecture_image (id, lecture_info_id, lecture_img_url, is_active, created_at, updated_at) VALUES (1, 1, 'http://lecture1.img.url', true, '2022-06-13 21:26:58', '2022-06-13 21:27:01');
+INSERT INTO lecture_image (id, lecture_info_id, lecture_img_url, is_active, created_at, updated_at) VALUES (2, 1, 'http://lecture1.img2.url', false, '2022-06-13 21:26:59', '2022-06-13 21:27:00');
+INSERT INTO lecture_image (id, lecture_info_id, lecture_img_url, is_active, created_at, updated_at) VALUES (3, 2, 'http://lecture2.img.url', false, '2022-06-13 21:27:02', '2022-06-13 21:27:01');
+INSERT INTO lecture_image (id, lecture_info_id, lecture_img_url, is_active, created_at, updated_at) VALUES (4, 3, 'http://lecture3.img.url', true, '2022-06-13 21:27:03', '2022-06-13 21:27:03');
+INSERT INTO lecture_image (id, lecture_info_id, lecture_img_url, is_active, created_at, updated_at) VALUES (5, 4, 'http://lecture4.img.url', true, '2022-06-13 21:27:04', '2022-06-13 21:27:04');
+INSERT INTO lecture_image (id, lecture_info_id, lecture_img_url, is_active, created_at, updated_at) VALUES (6, 5, 'http://lecture5.img.url', true, '2022-06-13 21:27:05', '2022-06-13 21:27:05');
+INSERT INTO lecture_image (id, lecture_info_id, lecture_img_url, is_active, created_at, updated_at) VALUES (7, 2, 'http://lecture2.img2.url', true, '2022-06-13 21:27:06', '2022-06-13 21:27:06');
+
+INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (1, 1, 4, '신청서를 받아주세요!', 'ACCEPT', true, '2022-06-13 22:48:17', '2022-06-13 22:48:17');
+INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (2, 2, 3, '제 신청서를 받아주세요!', 'ACCEPT', true, '2022-06-13 22:48:17', '2022-06-13 22:48:17');
+INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (3, 1, 2, '안받아주셔도 되요', 'REJECT', true, '2022-06-13 22:48:17', '2022-06-13 22:48:17');
+INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (4, 4, 1, '신청서를 받아주세요!', 'REQUEST', true, '2022-06-13 22:48:17', '2022-06-13 22:48:17');
+INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (5, 3, 3, '신청 거절해주세요', 'REJECT', true, '2022-06-13 22:51:03', '2022-06-13 22:51:04');
+INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (6, 3, 4, '신청합니다!', 'REQUEST', true, '2022-06-13 22:51:03', '2022-06-13 22:51:04');
+

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## 작업 내용 설명
- [로그인 / 회원가입 플로우](https://www.notion.so/sunsetmood/Diagram-cf3bad6d661b42e5aa4c673c02418a08)
- 관련 엔드포인트 추가
    - /api/user/user-exists
    - /api/user/identifier
    - /api/user/signin
    - /api/user/signup
    - /api/user/onboard
    - /api/user/refresh
- 관련하여 Core 소스가 다수 추가됨
- 통합 테스트 코드 작성
    - 컨트롤러 테스트가 곧 통합 테스트라고 보면 됨

## 주요 변경 사항
- 컨트롤러에 엔드포인트 추가
- Validation 추가
- jwt 발급 로직 추가
- 사용자 등록 로직 추가
- 온보딩 로직 추가
- 관련 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #23 
- resolved #28

@NaLDo627 @Park-Young-Hun

소스코드 양이 방대하므로, 화상 코드리뷰 진행 예정입니다.