### PR TITLE
[추가][수정] RefreshToken 테이블 추가, review 컬럼 is_public 추가 (#51) (#70)

### DIFF
--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/entity/RefreshToken.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/entity/RefreshToken.java
@@ -12,8 +12,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-@Table(name = "review")
-public class Review {
+@Table(name = "refresh_token")
+public class RefreshToken {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
@@ -23,20 +23,8 @@ public class Review {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToOne
-    @JoinColumn(name = "coach_id")
-    private Coach coach;
-
     @Column(nullable = false)
-    private String content;
-
-    @Builder.Default
-    @Column(nullable = false)
-    private boolean isPublic = true;
-
-    @Builder.Default
-    @Column(nullable = false)
-    private boolean isActive = true;
+    private String value;
 
     @Builder.Default
     @CreationTimestamp

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/RefreshTokenRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package kr.co.knowledgerally.core.user.repository;
+
+import kr.co.knowledgerally.core.user.entity.BallHistory;
+import kr.co.knowledgerally.core.user.entity.RefreshToken;
+import kr.co.knowledgerally.core.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    /**
+     * 사용자로 리프레시 토큰 찾기
+     * @param user 사용자
+     * @return 리프레시 토큰 Optional
+     */
+    Optional<RefreshToken> findByUser(User user);
+}

--- a/knowlly-core/src/main/resources/config/liquibase/changelog/20220615_drop_constraint_from_user.xml
+++ b/knowlly-core/src/main/resources/config/liquibase/changelog/20220615_drop_constraint_from_user.xml
@@ -9,7 +9,7 @@
 
     <changeSet id="20220615" author="hkpark">
         <addColumn tableName="user">
-            <column name="email_temp" type="varchar(255)">
+            <column name="email_temp" type="VARCHAR(255)">
                 <constraints nullable="true" unique="false"/>
             </column>
         </addColumn>

--- a/knowlly-core/src/main/resources/config/liquibase/changelog/20220621_add_refresh_table_and_add_is_public_column.xml
+++ b/knowlly-core/src/main/resources/config/liquibase/changelog/20220621_add_refresh_table_and_add_is_public_column.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="20220621" author="hkpark">
+        <createTable tableName="refresh_token">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" unique="true"/>
+            </column>
+            <column name="user_id" type="bigint">
+                <constraints foreignKeyName="fk_refresh_token_user" references="user(id)" nullable="false"/>
+            </column>
+            <column name="value" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addColumn tableName="review" >
+            <column name="is_public" type="boolean" value="true">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/knowlly-core/src/main/resources/config/liquibase/changelog/20220621_add_refresh_table_and_add_is_public_column.xml
+++ b/knowlly-core/src/main/resources/config/liquibase/changelog/20220621_add_refresh_table_and_add_is_public_column.xml
@@ -26,7 +26,7 @@
             </column>
         </createTable>
         <addColumn tableName="review" >
-            <column name="is_public" type="boolean" value="true">
+            <column name="is_public" type="boolean" valueBoolean="true">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/knowlly-core/src/main/resources/config/liquibase/master.xml
+++ b/knowlly-core/src/main/resources/config/liquibase/master.xml
@@ -11,4 +11,5 @@
     <include file="config/liquibase/changelog/20220613_kakao_id_change.xml"/>
     <include file="config/liquibase/changelog/20220614_add_portfolio_column.xml"/>
     <include file="config/liquibase/changelog/20220615_drop_constraint_from_user.xml"/>
+    <include file="config/liquibase/changelog/20220621_add_refresh_table_and_add_is_public_column.xml"/>
 </databaseChangeLog>

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/RefreshTokenRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,39 @@
+package kr.co.knowledgerally.core.user.repository;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.core.repository.AbstractRepositoryCrudTest;
+import kr.co.knowledgerally.core.user.entity.RefreshToken;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@KnowllyDataTest
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/refresh_token.xml",
+})
+class RefreshTokenRepositoryTest {
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
+
+    @Test
+    void 사용자로_리프레시_토큰_찾기_테스트() {
+        User user = testUserEntityFactory.createEntity(1L);
+
+        RefreshToken refreshToken = refreshTokenRepository.findByUser(user).orElseThrow();
+
+        assertEquals(1L, refreshToken.getId());
+        assertEquals(1L, refreshToken.getUser().getId());
+        assertEquals("refresh_token_value1", refreshToken.getValue());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 52, 34), refreshToken.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 52, 35), refreshToken.getUpdatedAt());
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/crud/RefreshTokenRepositoryCrudTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/crud/RefreshTokenRepositoryCrudTest.java
@@ -1,0 +1,69 @@
+package kr.co.knowledgerally.core.user.repository.crud;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.ExpectedDatabase;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import kr.co.knowledgerally.core.core.repository.AbstractRepositoryCrudTest;
+import kr.co.knowledgerally.core.user.entity.BallHistory;
+import kr.co.knowledgerally.core.user.entity.RefreshToken;
+import kr.co.knowledgerally.core.user.repository.RefreshTokenRepository;
+import kr.co.knowledgerally.core.user.util.TestRefreshTokenEntityFactory;
+import liquibase.pro.packaged.T;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/refresh_token.xml",
+})
+class RefreshTokenRepositoryCrudTest extends AbstractRepositoryCrudTest {
+
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    TestRefreshTokenEntityFactory testRefreshTokenEntityFactory = new TestRefreshTokenEntityFactory();
+
+    @Override
+    @Test
+    protected void selectTest() {
+        RefreshToken refreshToken = refreshTokenRepository.findById(1L).orElseThrow();
+
+        assertEquals(1L, refreshToken.getId());
+        assertEquals(1L, refreshToken.getUser().getId());
+        assertEquals("refresh_token_value1", refreshToken.getValue());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 52, 34), refreshToken.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 52, 35), refreshToken.getUpdatedAt());
+    }
+
+    @Override
+    @Test
+    @ExpectedDatabase(value = "classpath:dbunit/expected/crud/refresh_token_insert_test.xml",
+            assertionMode = DatabaseAssertionMode.NON_STRICT)
+    protected void insertTest() {
+        RefreshToken refreshToken = testRefreshTokenEntityFactory.createEntity(5L, 5L);
+        refreshTokenRepository.saveAndFlush(refreshToken);
+    }
+
+    @Override
+    @Test
+    @ExpectedDatabase(value = "classpath:dbunit/expected/crud/refresh_token_update_test.xml",
+            assertionMode = DatabaseAssertionMode.NON_STRICT)
+    protected void updateTest() {
+        RefreshToken refreshToken = refreshTokenRepository.findById(1L).orElseThrow();
+        refreshToken.setValue("changed_value");
+        entityManager.flush();
+    }
+
+    @Override
+    @Test
+    @ExpectedDatabase(value = "classpath:dbunit/expected/crud/refresh_token_delete_test.xml",
+            assertionMode = DatabaseAssertionMode.NON_STRICT)
+    protected void deleteTest() {
+        refreshTokenRepository.deleteById(1L);
+        entityManager.flush();
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/util/TestRefreshTokenEntityFactory.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/util/TestRefreshTokenEntityFactory.java
@@ -1,0 +1,39 @@
+package kr.co.knowledgerally.core.user.util;
+
+import kr.co.knowledgerally.core.core.util.TestEntityFactory;
+import kr.co.knowledgerally.core.user.entity.BallHistory;
+import kr.co.knowledgerally.core.user.entity.RefreshToken;
+import kr.co.knowledgerally.core.user.entity.User;
+
+/**
+ * 테스트용 리프레시 토큰 엔티티 생성 팩토리
+ */
+public class TestRefreshTokenEntityFactory implements TestEntityFactory<RefreshToken> {
+    private final TestEntityFactory<User> testUserEntityFactory = new TestUserEntityFactory();
+
+    /**
+     * 테스트용 리프레시 토큰 엔티티를 생성한다.
+     *
+     * @param entityId 생성될 엔티티 Id
+     * @return 생성된 볼 내역 엔티티
+     */
+    @Override
+    public RefreshToken createEntity(long entityId) {
+        return createEntity(entityId, 1L);
+    }
+
+    /**
+     * 테스트용 리프레시 토큰 엔티티를 생성한다.
+     *
+     * @param entityId 생성될 엔티티 Id
+     * @param userId   생성될 엔티티의 사용자 Id
+     * @return 생성된 볼 내역 엔티티
+     */
+    public RefreshToken createEntity(long entityId, long userId) {
+        return RefreshToken.builder()
+                .id(entityId)
+                .user(testUserEntityFactory.createEntity(userId))
+                .value(String.format("refresh_token_value%d", entityId))
+                .build();
+    }
+}

--- a/knowlly-core/src/test/resources/dbunit/entity/refresh_token.xml
+++ b/knowlly-core/src/test/resources/dbunit/entity/refresh_token.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <refresh_token id="1" user_id="1" value="refresh_token_value1" created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
+    <refresh_token id="2" user_id="2" value="refresh_token_value2" created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
+    <refresh_token id="3" user_id="3" value="refresh_token_value3" created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
+    <refresh_token id="4" user_id="4" value="refresh_token_value4" created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
+
+</dataset>

--- a/knowlly-core/src/test/resources/dbunit/entity/review.xml
+++ b/knowlly-core/src/test/resources/dbunit/entity/review.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
     <review id="1" user_id="1" coach_id="3" content="테스트3은 좋은 코치입니다!" is_active="true" created_at="2022-06-13 22:19:14"
-            updated_at="2022-06-13 22:19:15"/>
+            updated_at="2022-06-13 22:19:15" is_public="true"/>
     <review id="2" user_id="2" coach_id="1" content="테스트1 코치는 친절했어요~" is_active="true" created_at="2022-06-13 22:19:14"
-            updated_at="2022-06-13 22:19:15"/>
+            updated_at="2022-06-13 22:19:15" is_public="true"/>
     <review id="3" user_id="4" coach_id="3" content="테스트3 코치는 좀 별로였습니다" is_active="true"
-            created_at="2022-06-13 22:19:16" updated_at="2022-06-13 22:19:16"/>
+            created_at="2022-06-13 22:19:16" updated_at="2022-06-13 22:19:16" is_public="false"/>
     <review id="4" user_id="3" coach_id="1" content="테스트1 코치가 최고에요~" is_active="true" created_at="2022-06-13 22:19:18"
-            updated_at="2022-06-13 22:19:17"/>
+            updated_at="2022-06-13 22:19:17" is_public="true"/>
 
 </dataset>

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/refresh_token_delete_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/refresh_token_delete_test.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <refresh_token id="2" user_id="2" value="refresh_token_value2" created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
+    <refresh_token id="3" user_id="3" value="refresh_token_value3" created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
+    <refresh_token id="4" user_id="4" value="refresh_token_value4" created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
+
+</dataset>

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/refresh_token_insert_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/refresh_token_insert_test.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <refresh_token id="1" user_id="1" value="refresh_token_value1" />
+    <refresh_token id="2" user_id="2" value="refresh_token_value2" />
+    <refresh_token id="3" user_id="3" value="refresh_token_value3" />
+    <refresh_token id="4" user_id="4" value="refresh_token_value4" />
+    <refresh_token id="5" user_id="5" value="refresh_token_value5" />
+
+</dataset>

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/refresh_token_update_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/refresh_token_update_test.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <refresh_token id="1" user_id="1" value="changed_value" created_at="2022-06-13 21:52:34" />
+    <refresh_token id="2" user_id="2" value="refresh_token_value2" created_at="2022-06-13 21:52:34" />
+    <refresh_token id="3" user_id="3" value="refresh_token_value3" created_at="2022-06-13 21:52:34" />
+    <refresh_token id="4" user_id="4" value="refresh_token_value4" created_at="2022-06-13 21:52:34" />
+
+</dataset>

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/review_delete_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/review_delete_test.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
     <review id="2" user_id="2" coach_id="1" content="테스트1 코치는 친절했어요~" is_active="true" created_at="2022-06-13 22:19:14"
-            updated_at="2022-06-13 22:19:15"/>
+            updated_at="2022-06-13 22:19:15" is_public="true"/>
     <review id="3" user_id="4" coach_id="3" content="테스트3 코치는 좀 별로였습니다" is_active="true"
-            created_at="2022-06-13 22:19:16" updated_at="2022-06-13 22:19:16"/>
+            created_at="2022-06-13 22:19:16" updated_at="2022-06-13 22:19:16" is_public="false"/>
     <review id="4" user_id="3" coach_id="1" content="테스트1 코치가 최고에요~" is_active="true" created_at="2022-06-13 22:19:18"
-            updated_at="2022-06-13 22:19:17"/>
+            updated_at="2022-06-13 22:19:17" is_public="true"/>
 
 </dataset>

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/review_insert_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/review_insert_test.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
-    <review id="1" user_id="1" coach_id="3" content="테스트3은 좋은 코치입니다!" is_active="true" />
-    <review id="2" user_id="2" coach_id="1" content="테스트1 코치는 친절했어요~" is_active="true" />
-    <review id="3" user_id="4" coach_id="3" content="테스트3 코치는 좀 별로였습니다" is_active="true" />
-    <review id="4" user_id="3" coach_id="1" content="테스트1 코치가 최고에요~" is_active="true" />
-    <review id="5" user_id="1" coach_id="2" content="테스트5 내용" is_active="true" />
+    <review id="1" user_id="1" coach_id="3" content="테스트3은 좋은 코치입니다!" is_active="true" is_public="true" />
+    <review id="2" user_id="2" coach_id="1" content="테스트1 코치는 친절했어요~" is_active="true" is_public="true" />
+    <review id="3" user_id="4" coach_id="3" content="테스트3 코치는 좀 별로였습니다" is_active="true" is_public="false" />
+    <review id="4" user_id="3" coach_id="1" content="테스트1 코치가 최고에요~" is_active="true" is_public="true" />
+    <review id="5" user_id="1" coach_id="2" content="테스트5 내용" is_active="true" is_public="true" />
 
 </dataset>

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/review_update_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/review_update_test.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
-    <review id="1" user_id="1" coach_id="3" content="내용변경" is_active="true" created_at="2022-06-13 22:19:14" />
-    <review id="2" user_id="2" coach_id="1" content="테스트1 코치는 친절했어요~" is_active="true" created_at="2022-06-13 22:19:14" />
+    <review id="1" user_id="1" coach_id="3" content="내용변경" is_active="true" created_at="2022-06-13 22:19:14" is_public="true" />
+    <review id="2" user_id="2" coach_id="1" content="테스트1 코치는 친절했어요~" is_active="true" created_at="2022-06-13 22:19:14" is_public="true" />
     <review id="3" user_id="4" coach_id="3" content="테스트3 코치는 좀 별로였습니다" is_active="true"
-            created_at="2022-06-13 22:19:16" />
-    <review id="4" user_id="3" coach_id="1" content="테스트1 코치가 최고에요~" is_active="true" created_at="2022-06-13 22:19:18" />
+            created_at="2022-06-13 22:19:16" is_public="false" />
+    <review id="4" user_id="3" coach_id="1" content="테스트1 코치가 최고에요~" is_active="true" created_at="2022-06-13 22:19:18" is_public="true" />
 
 </dataset>

--- a/knowlly-core/src/test/resources/sql/integration.sql
+++ b/knowlly-core/src/test/resources/sql/integration.sql
@@ -20,6 +20,12 @@ INSERT INTO ball_history (id, user_id, title, content, count, is_active, created
 INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (6, 4, '온보딩', '온보딩', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
 INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (7, 5, '운영 클래스', '프랑스어 수업', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
 
+INSERT INTO refresh_token (id, user_id, value, created_at, updated_at) VALUES (1, 1, 'refresh_token1', '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO refresh_token (id, user_id, value, created_at, updated_at) VALUES (2, 2, 'refresh_token2', '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO refresh_token (id, user_id, value, created_at, updated_at) VALUES (3, 3, 'refresh_token3', '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO refresh_token (id, user_id, value, created_at, updated_at) VALUES (4, 4, 'refresh_token4', '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO refresh_token (id, user_id, value, created_at, updated_at) VALUES (5, 5, 'refresh_token5', '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+
 INSERT INTO coach (id, user_id, introduce, is_active, created_at, updated_at) VALUES (1, 1, '안녕하세요. 테스트1 코치입니다.', true, '2022-06-13 21:57:17', '2022-06-13 21:57:17');
 INSERT INTO coach (id, user_id, introduce, is_active, created_at, updated_at) VALUES (2, 3, '안녕하세요. 테스트3 코치입니다.', true, '2022-06-13 21:57:18', '2022-06-13 21:57:18');
 INSERT INTO coach (id, user_id, introduce, is_active, created_at, updated_at) VALUES (3, 4, '안녕하세요. 테스트4 코치입니다.', true, '2022-06-13 21:57:18', '2022-06-13 21:57:19');
@@ -30,10 +36,10 @@ INSERT INTO notification (id, user_id, coach_id, content, noti_type, is_read, is
 INSERT INTO notification (id, user_id, coach_id, content, noti_type, is_read, is_active, created_at, updated_at) VALUES (3, 1, 2, '알림 내용', 'PLAYER', false, true, '2022-06-13 22:17:08', '2022-06-13 22:17:09');
 INSERT INTO notification (id, user_id, coach_id, content, noti_type, is_read, is_active, created_at, updated_at) VALUES (4, 4, 3, '알림 내용', 'PLAYER', true, true, '2022-06-13 22:17:08', '2022-06-13 22:17:09');
 
-INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at) VALUES (1, 1, 3, '테스트3은 좋은 코치입니다!', true, '2022-06-13 22:19:14', '2022-06-13 22:19:15');
-INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at) VALUES (2, 2, 1, '테스트1 코치는 친절했어요~', true, '2022-06-13 22:19:14', '2022-06-13 22:19:15');
-INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at) VALUES (3, 4, 3, '테스트3 코치는 좀 별로였습니다', true, '2022-06-13 22:19:16', '2022-06-13 22:19:16');
-INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at) VALUES (4, 3, 1, '테스트1 코치가 최고에요~', true, '2022-06-13 22:19:18', '2022-06-13 22:19:17');
+INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at, is_public) VALUES (1, 1, 3, '테스트3은 좋은 코치입니다!', true, '2022-06-13 22:19:14', '2022-06-13 22:19:15', true);
+INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at, is_public) VALUES (2, 2, 1, '테스트1 코치는 친절했어요~', true, '2022-06-13 22:19:14', '2022-06-13 22:19:15', true);
+INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at, is_public) VALUES (3, 4, 3, '테스트3 코치는 좀 별로였습니다', true, '2022-06-13 22:19:16', '2022-06-13 22:19:16', false);
+INSERT INTO review (id, user_id, coach_id, content, is_active, created_at, updated_at, is_public) VALUES (4, 3, 1, '테스트1 코치가 최고에요~', true, '2022-06-13 22:19:18', '2022-06-13 22:19:17', true);
 
 INSERT INTO category (id, category_name, is_active) VALUES (1, '기획 / PM', true);
 INSERT INTO category (id, category_name, is_active) VALUES (2, '디자인', true);


### PR DESCRIPTION
## 작업 내용 설명
- refresh_token 저장이 필요하여, 테이블 추가
- review 테이블의 공개여부 판단하는 컬럼 추가

## 주요 변경 사항
- refresh_token 테이블 추가 및 관련 코드, 테스트 추가
- review 테이블에 is_public 컬럼 추가, 관련 테스트 코드 수정

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #51
- resolved #70

@NaLDo627 @Park-Young-Hun
