### PR TITLE
[수정] /api/user/signup 응답 스키마 변경 (#75)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserSignUpDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserSignUpDto.java
@@ -1,0 +1,23 @@
+package kr.co.knowledgerally.api.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.api.core.jwt.dto.JwtToken;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(value = "사용자 회원가입 응답 모델", description = "사용자 회원가입 응답 모델")
+public class UserSignUpDto {
+    @ApiModelProperty(value = "발급된 jwt 토큰")
+    @JsonProperty
+    private JwtToken jwtToken;
+
+    @ApiModelProperty(value = "사용자 프로필")
+    @JsonProperty
+    private UserDto user;
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserAuthController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserAuthController.java
@@ -8,6 +8,7 @@ import kr.co.knowledgerally.api.core.jwt.dto.TokenProvider;
 import kr.co.knowledgerally.api.core.jwt.service.JwtService;
 import kr.co.knowledgerally.api.core.oauth2.dto.OAuth2Profile;
 import kr.co.knowledgerally.api.core.oauth2.service.OAuth2ServiceFactory;
+import kr.co.knowledgerally.api.user.dto.UserSignUpDto;
 import kr.co.knowledgerally.api.user.service.UserSignUpService;
 import kr.co.knowledgerally.core.user.service.UserService;
 import lombok.AllArgsConstructor;
@@ -54,7 +55,7 @@ public class UserAuthController {
             @ApiResponse(code = 400, message = "잘못된 요청, 이미 등록한 사용자"),
     })
     @PostMapping("/signup")
-    public ResponseEntity<ApiResult<JwtToken>> signup(
+    public ResponseEntity<ApiResult<UserSignUpDto>> signup(
             @ApiParam(value = "프로바이더 액세스 토큰", required = true) @RequestBody @Valid ProviderToken providerToken) {
         return ResponseEntity.ok(ApiResult.ok(
                 signUpService.signUp(providerToken)));

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserAuthControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserAuthControllerTest.java
@@ -95,8 +95,9 @@ class UserAuthControllerTest extends AbstractControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                 ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.knowllyAccessToken").value(TEST_KNOWLLY_ACCESS_TOKEN))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.knowllyRefreshToken").value(TEST_KNOWLLY_REFRESH_TOKEN))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.jwtToken.knowllyAccessToken").value(TEST_KNOWLLY_ACCESS_TOKEN))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.jwtToken.knowllyRefreshToken").value(TEST_KNOWLLY_REFRESH_TOKEN))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.username").value("테스트이름"))
                 .andDo(print());
     }
 


### PR DESCRIPTION
## 작업 내용 설명
- 회원 등록 엔드포인트 응답을 사용자 정보를 포함해서 리턴

## 주요 변경 사항
- AS-IS
    - 회원 등록시 Jwt토큰만 발급
- TO-BE
    - 회원 등록시 Jwt토큰과 함께 프로바이더(카카오)에서 가져온 정보 리턴

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #75

@NaLDo627 @Park-Young-Hun
