### PR TITLE
Fix: UserDto identifier 속성 ReadOnly로 전환 (#79)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserDto.java
@@ -37,11 +37,6 @@ public class UserDto {
     @JsonProperty(index = PropertyDisplayOrder.PORTFOLIO)
     private String portfolio;
 
-    @NotBlank
-    @ApiModelProperty(value = "사용자 식별값", required = true, position = PropertyDisplayOrder.IDENTIFIER)
-    @JsonProperty(index = PropertyDisplayOrder.IDENTIFIER)
-    private String identifier;
-
     @SuperBuilder
     @Getter
     @Setter
@@ -68,6 +63,10 @@ public class UserDto {
                 position = PropertyDisplayOrder.IS_PUSH_ACTIVE)
         @JsonProperty(index = PropertyDisplayOrder.IS_PUSH_ACTIVE)
         private boolean isPushActive;
+
+        @ApiModelProperty(value = "사용자 식별값", position = PropertyDisplayOrder.IDENTIFIER)
+        @JsonProperty(index = PropertyDisplayOrder.IDENTIFIER)
+        private String identifier;
     }
 
     private static class PropertyDisplayOrder {

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserOnboardService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserOnboardService.java
@@ -38,6 +38,7 @@ public class UserOnboardService {
                                            User loggedInUser) {
         User onBoardingUser = userMapper.toEntity(userOnboardDto.getUser());
         onBoardingUser.setId(loggedInUser.getId());
+        onBoardingUser.setIdentifier(loggedInUser.getIdentifier());
         User savedUser = userService.saveUser(onBoardingUser);
         UserImage savedUserImage = userImageService.saveUserImage(userImageMapper.toEntity(userOnboardDto.getUserImage(), savedUser));
 

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/UserMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/UserMapperTest.java
@@ -43,6 +43,5 @@ class UserMapperTest {
         assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", user.getIntro());
         assertEquals("kakao_test1", user.getKakaoId());
         assertEquals("포트폴리오1", user.getPortfolio());
-        assertEquals("identifier1", user.getIdentifier());
     }
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/util/TestUserDtoFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/util/TestUserDtoFactory.java
@@ -23,7 +23,6 @@ public class TestUserDtoFactory implements TestDtoFactory<UserDto> {
                 .intro("안녕하세요. 저는 테스트1이라고 합니다.")
                 .kakaoId("kakao_test1")
                 .portfolio("포트폴리오1")
-                .identifier("identifier1")
                 .build();
     }
 

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserControllerTest.java
@@ -23,8 +23,7 @@ class UserControllerTest extends AbstractControllerTest {
                         "\"username\": \"테스트이름\"," +
                         "\"intro\": \"테스트 자기소개\"," +
                         "\"kakaoId\": \"test_kakao_id\"," +
-                        "\"portfolio\": \"portfolio.io\"," +
-                        "\"identifier\": \"kakao_12341234\"" +
+                        "\"portfolio\": \"portfolio.io\"" +
                 "   }," +
                     "\"userImage\" : {" +
                         "\"userImgUrl\": \"http://testImgUrl.com\"" +
@@ -42,7 +41,7 @@ class UserControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.intro").value("테스트 자기소개"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.kakaoId").value("test_kakao_id"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.portfolio").value("portfolio.io"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.identifier").value("kakao_12341234"))
+//                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.identifier").value("kakao_12341234"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.userImage.userImgUrl").value("http://testImgUrl.com"));
     }
 


### PR DESCRIPTION
## 작업 내용 설명
- UserDto의 identifier는 외부에서 들어올 필요가 없기 때문에, ReadOnly처리한다.

## 주요 변경 사항
- identifier 속성을 ReadOnly 영역으로 이동

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #79

@NaLDo627 @Park-Young-Hun
