### PR TITLE
[기능] 프로필 이미지 업로드 기능 추가 (#40)

### DIFF
--- a/.github/workflows/api-test-and-deploy-dev.yml
+++ b/.github/workflows/api-test-and-deploy-dev.yml
@@ -49,6 +49,8 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Gradle 테스트 및 실행파일 생성
         run: ./gradlew build test bootJar -Dfile.encoding=UTF-8 -Duser.timezone=Asia/Seoul --info
+        env:
+          SPRING_PROFILES_ACTIVE: dev
 
       - uses: actions/upload-artifact@v2
         name: 생성한 파일 업로드

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ project(':knowlly-api') {
 		implementation project(":knowlly-core")
 		testImplementation project(':knowlly-core').sourceSets.test.output
 
+		implementation 'org.springframework.cloud:spring-cloud-aws-context:2.2.1.RELEASE'
 		implementation 'org.springframework.boot:spring-boot-starter-web'
 		implementation 'io.springfox:springfox-swagger2:2.9.2'
 		implementation 'io.springfox:springfox-swagger-ui:2.9.2'

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/FileNameGenerator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/FileNameGenerator.java
@@ -1,0 +1,10 @@
+package kr.co.knowledgerally.api.core.component;
+
+public interface FileNameGenerator {
+    /**
+     * 파일 이름을 구현 규칙에 맞게 생성합니다.
+     * @param originalFileName 파일 원본 이름
+     * @return 생성된 파일 이름
+     */
+    String generate(String originalFileName);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/FileUploader.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/FileUploader.java
@@ -1,0 +1,13 @@
+package kr.co.knowledgerally.api.core.component;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileUploader {
+    /**
+     * 멀티파트 파일을 업로드합니다.
+     * @param mFile 업로드 될 파일
+     * @param saveFilePath 파일 경로
+     * @return 다운로드 가능한 URL
+     */
+    String uploadMultiPartFile(MultipartFile mFile, String saveFilePath);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/S3FileUploader.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/S3FileUploader.java
@@ -1,0 +1,71 @@
+package kr.co.knowledgerally.api.core.component;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.internal.Mimetypes;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import kr.co.knowledgerally.api.core.util.PathUtil;
+import kr.co.knowledgerally.core.core.exception.KnowllyException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3FileUploader implements FileUploader {
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.domain-uri}")
+    private String domainUri;
+
+    /**
+     * 멀티파트 파일을 업로드합니다.
+     * @param mFile 업로드 될 파일
+     * @param saveFilePath 파일 경로
+     * @return 다운로드 가능한 URL
+     */
+    @Override
+    public String uploadMultiPartFile(MultipartFile mFile, String saveFilePath) {
+        String fullFilePath = PathUtil.replaceWindowPathToLinuxPath(saveFilePath);
+        S3ObjectUploadDto s3ObjectUploadDto = buildObjectUploadDto(mFile);
+
+        s3Client.putObject(new PutObjectRequest(
+                bucket, fullFilePath, s3ObjectUploadDto.getByteArrayInputStream(), s3ObjectUploadDto.getObjectMetadata()
+        ).withCannedAcl(CannedAccessControlList.PublicRead));
+
+        return domainUri + saveFilePath;
+    }
+
+    private S3ObjectUploadDto buildObjectUploadDto(MultipartFile file) {
+        try {
+            ObjectMetadata objMeta = new ObjectMetadata();
+            objMeta.setContentType(Mimetypes.getInstance().getMimetype(file.getName()));
+            byte[] bytes = IOUtils.toByteArray(file.getInputStream());
+            objMeta.setContentLength(bytes.length);
+            return new S3ObjectUploadDto(
+                    new ByteArrayInputStream(bytes),
+                    objMeta
+            );
+        } catch (IOException e) {
+            throw new KnowllyException(e);
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private static class S3ObjectUploadDto {
+        private final ByteArrayInputStream byteArrayInputStream;
+        private final ObjectMetadata objectMetadata;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/UuidFileNameGenerator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/UuidFileNameGenerator.java
@@ -1,0 +1,20 @@
+package kr.co.knowledgerally.api.core.component;
+
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class UuidFileNameGenerator implements FileNameGenerator {
+    private static final String UNDER_DASH = "_";
+
+    /**
+     * 파일 이름을 구현 규칙에 맞게 생성합니다.
+     * @param originalFileName 파일 원본 이름
+     * @return 생성된 파일 이름
+     */
+    @Override
+    public String generate(String originalFileName) {
+        return originalFileName + UNDER_DASH + UUID.randomUUID();
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/UuidFileNameGenerator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/UuidFileNameGenerator.java
@@ -15,6 +15,6 @@ public class UuidFileNameGenerator implements FileNameGenerator {
      */
     @Override
     public String generate(String originalFileName) {
-        return originalFileName + UNDER_DASH + UUID.randomUUID();
+        return UUID.randomUUID() + UNDER_DASH + originalFileName;
     }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/AmazonS3Config.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/AmazonS3Config.java
@@ -1,0 +1,31 @@
+package kr.co.knowledgerally.api.core.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AmazonS3Config {
+    @Value("${cloud.aws.credentials.access_key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret_key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
+
+        //AmazonS3ClientBuilder를 통해 S3 Client를 가져와야 하는데, 자격증명을 해줘야 S3 Client를 가져올 수 있기 때문입니다.
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(this.region)
+                .build();
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/util/PathUtil.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/util/PathUtil.java
@@ -1,0 +1,9 @@
+package kr.co.knowledgerally.api.core.util;
+
+public class PathUtil {
+    private PathUtil() { }
+
+    public static String replaceWindowPathToLinuxPath(String path) {
+        return path.replaceAll("\\\\", "/");
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserImageUploadService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserImageUploadService.java
@@ -1,0 +1,45 @@
+package kr.co.knowledgerally.api.user.service;
+
+import kr.co.knowledgerally.api.core.component.FileNameGenerator;
+import kr.co.knowledgerally.api.core.component.FileUploader;
+import kr.co.knowledgerally.api.user.dto.UserImageDto;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.service.UserImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.transaction.Transactional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserImageUploadService {
+    public static final String MEMBER_IMAGE_DIR_NAME = "user-image";
+    public static final String DASH = "/";
+
+    private final FileNameGenerator fileNameGenerator;
+    private final FileUploader fileUploader;
+    private final UserImageService userImageService;
+
+    /**
+     * Multipart File 을 저장하고, 저장 경로를 리턴한다.
+     *
+     * @param imageFile 요청으로 들어온 Multipart File
+     * @return 웹상에서 저장된 경로
+     */
+    @Transactional
+    public UserImageDto upload(MultipartFile imageFile, User loggedInUser) {
+        String generatedFileName = fileNameGenerator.generate(imageFile.getOriginalFilename());
+        generatedFileName = MEMBER_IMAGE_DIR_NAME + DASH + loggedInUser.getId() + DASH + generatedFileName;
+        String downloadableUrl = fileUploader.uploadMultiPartFile(imageFile, generatedFileName);
+
+        userImageService.saveUserImage(UserImage.builder()
+                        .user(loggedInUser)
+                        .userImgUrl(downloadableUrl)
+                .build());
+
+        return new UserImageDto(downloadableUrl);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserImageController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserImageController.java
@@ -1,0 +1,36 @@
+package kr.co.knowledgerally.api.user.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.core.annotation.CurrentUser;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.user.dto.UserImageDto;
+import kr.co.knowledgerally.api.user.service.UserImageUploadService;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import springfox.documentation.annotations.ApiIgnore;
+
+/**
+ * 회원 정보 관련 엔드포인트
+ */
+@Api(value = "회원 정보 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserImageController {
+    private final UserImageUploadService userImageUploadService;
+
+    @ApiOperation(value = "프로필 이미지 업로드", notes = "프로필 이미지를 업로드할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "업로드 성공"),
+    })
+    @PostMapping("/image")
+    public ResponseEntity<ApiResult<UserImageDto>> signup(
+            @ApiIgnore @CurrentUser User loggedInUser,
+            @ApiParam(value = "업로드할 이미지", required = true)
+            @RequestParam("image") MultipartFile image) {
+        return ResponseEntity.ok(ApiResult.ok(userImageUploadService.upload(image, loggedInUser)));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/component/AmazonS3ClientTestDev.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/component/AmazonS3ClientTestDev.java
@@ -1,0 +1,69 @@
+package kr.co.knowledgerally.api.core.component;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.internal.Mimetypes;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+@EnabledIfEnvironmentVariable(named = "SPRING_PROFILES_ACTIVE", matches = "dev")
+@ActiveProfiles("dev")
+@SpringBootTest
+class AmazonS3ClientTestDev {
+    @Autowired
+    private AmazonS3 s3Client;
+
+    private static final String TEST_FILE_NAME = "hello.txt";
+    private static final MultipartFile TEST_MULTIPART_FILE = new MockMultipartFile(
+            "image",
+            "hello.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "Hello, World!".getBytes()
+    );
+
+    private String bucket = "knollydev";
+
+    @Test
+    public void S3_파일_업로드_테스트() throws IOException {
+        ObjectMetadata objMeta = buildObjectMetadata(TEST_MULTIPART_FILE);
+
+        byte[] bytes = IOUtils.toByteArray(TEST_MULTIPART_FILE.getInputStream());
+        ByteArrayInputStream byteArrayIs = new ByteArrayInputStream(bytes);
+
+//        String uuid = UUID.randomUUID().toString();
+//        fileName = fileName+uuid;
+
+        PutObjectRequest putObjReq = new PutObjectRequest(bucket, TEST_FILE_NAME, byteArrayIs, objMeta);
+        //업로드를 하기 위해 사용되는 함수입니다.
+        s3Client.putObject(putObjReq.withCannedAcl(CannedAccessControlList.PublicRead));
+        //외부에 공개할 이미지이므로, 해당 파일에 public read 권한을 추가합니다.
+        //업로드를 한 후, 해당 URL을 DB에 저장할 수 있도록 컨트롤러로 URL을 반환합니다.
+        System.out.println(TEST_FILE_NAME);
+    }
+
+    private ObjectMetadata buildObjectMetadata(MultipartFile file) throws IOException {
+        ObjectMetadata objMeta = new ObjectMetadata();
+        objMeta.setContentType(Mimetypes.getInstance().getMimetype(file.getName()));
+        byte[] bytes = IOUtils.toByteArray(file.getInputStream());
+        objMeta.setContentLength(bytes.length);
+        return objMeta;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        s3Client.deleteObject(bucket, TEST_FILE_NAME);
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/component/S3FileUploaderTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/component/S3FileUploaderTest.java
@@ -1,0 +1,53 @@
+package kr.co.knowledgerally.api.core.component;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class S3FileUploaderTest {
+    @InjectMocks
+    private S3FileUploader s3FileUploader;
+
+    @Mock
+    private AmazonS3 amazonS3;
+
+    private static final String TEST_BUCKET = "testbucket";
+    private static final String TEST_DOMAIN_URI = "http://testurl.com/";
+    private static final String TEST_FILE_PATH = "hello.txt";
+    private static final MultipartFile TEST_MULTIPART_FILE = new MockMultipartFile(
+            "image",
+            "hello.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "Hello, World!".getBytes()
+    );
+
+    @Test
+    void 파일_업로더_테스트() {
+        ReflectionTestUtils.setField(s3FileUploader, "bucket", TEST_BUCKET);
+        ReflectionTestUtils.setField(s3FileUploader, "domainUri", TEST_DOMAIN_URI);
+        ArgumentCaptor<PutObjectRequest> argumentCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        when(amazonS3.putObject(argumentCaptor.capture())).thenReturn(new PutObjectResult());
+
+        String downloadableUrl = s3FileUploader.uploadMultiPartFile(TEST_MULTIPART_FILE, TEST_FILE_PATH);
+
+        assertEquals(TEST_DOMAIN_URI + TEST_FILE_PATH, downloadableUrl);
+        PutObjectRequest captured = argumentCaptor.getValue();
+        assertEquals(TEST_BUCKET, captured.getBucketName());
+        assertEquals(TEST_FILE_PATH, captured.getKey());
+    }
+
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/component/UuidFileNameGeneratorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/component/UuidFileNameGeneratorTest.java
@@ -1,0 +1,17 @@
+package kr.co.knowledgerally.api.core.component;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UuidFileNameGeneratorTest {
+    @Test
+    void Uuid_이름_생성_테스트() {
+        String originalFileName = "원본파일이름";
+        FileNameGenerator fileNameGenerator = new UuidFileNameGenerator();
+
+        String generated = fileNameGenerator.generate(originalFileName);
+        System.out.println(generated);
+        assertTrue(generated.startsWith("원본파일이름_"));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/component/UuidFileNameGeneratorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/component/UuidFileNameGeneratorTest.java
@@ -12,6 +12,6 @@ class UuidFileNameGeneratorTest {
 
         String generated = fileNameGenerator.generate(originalFileName);
         System.out.println(generated);
-        assertTrue(generated.startsWith("원본파일이름_"));
+        assertTrue(generated.endsWith("_원본파일이름"));
     }
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserImageControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserImageControllerTest.java
@@ -1,0 +1,55 @@
+package kr.co.knowledgerally.api.user.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.core.component.FileNameGenerator;
+import kr.co.knowledgerally.api.core.component.FileUploader;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserImageControllerTest extends AbstractControllerTest {
+    private static final String USER_IMAGE_UPLOAD_URL = "/api/user/image";
+
+    @MockBean
+    private FileNameGenerator fileNameGenerator;
+
+    @MockBean
+    private FileUploader fileUploader;
+
+    @Test
+    @WithMockKnowllyUser
+    public void 이미지_업로드_테스트() throws Exception {
+        MockMultipartFile mockMultipartFile = new MockMultipartFile(
+                "image",
+                "hello.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                "Hello, World!".getBytes()
+        );
+
+        when(fileNameGenerator.generate(eq("hello.txt"))).thenReturn("hello.txt_generated");
+        when(fileUploader.uploadMultiPartFile(any(), eq("user-image/1/hello.txt_generated")))
+                .thenReturn("http://testurl.com/user-image/1/hello.txt_generated");
+
+        mockMvc.perform(
+                        multipart(USER_IMAGE_UPLOAD_URL)
+                                .file(mockMultipartFile)
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.userImgUrl")
+                        .value("http://testurl.com/user-image/1/hello.txt_generated"))
+                .andDo(print());
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/entity/UserImage.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/entity/UserImage.java
@@ -39,4 +39,8 @@ public class UserImage {
     @UpdateTimestamp
     @Column(nullable = false)
     private LocalDateTime updatedAt = LocalDateTime.now();
+
+    public void makeInactive() {
+        this.isActive = false;
+    }
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/UserImageRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/UserImageRepository.java
@@ -1,7 +1,16 @@
 package kr.co.knowledgerally.core.user.repository;
 
+import kr.co.knowledgerally.core.user.entity.User;
 import kr.co.knowledgerally.core.user.entity.UserImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserImageRepository extends JpaRepository<UserImage, Long> {
+    /**
+     * 사용자로 이미지들을 찾는다.
+     * @param user 사용자
+     * @return 사용자 이미지 목록
+     */
+    List<UserImage> findAllByUser(User user);
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserImageService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserImageService.java
@@ -12,6 +12,9 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static kr.co.knowledgerally.core.core.message.ErrorMessage.NOT_EXIST_USER;
 
 @Validated
@@ -22,6 +25,11 @@ public class UserImageService {
 
     @Transactional
     public UserImage saveUserImage(@Valid UserImage newUserImage) {
+        List<UserImage> userImages = userImageRepository.findAllByUser(newUserImage.getUser());
+        for (UserImage userImage : userImages) {
+            userImage.makeInactive();
+        }
+        newUserImage.setActive(true);
         return userImageRepository.saveAndFlush(newUserImage);
     }
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserImageService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserImageService.java
@@ -23,6 +23,11 @@ import static kr.co.knowledgerally.core.core.message.ErrorMessage.NOT_EXIST_USER
 public class UserImageService {
     private final UserImageRepository userImageRepository;
 
+    /**
+     * 사용자 이미지 저장
+     * @param newUserImage 신규 이미지
+     * @return 저장 결과 이미지 객체
+     */
     @Transactional
     public UserImage saveUserImage(@Valid UserImage newUserImage) {
         List<UserImage> userImages = userImageRepository.findAllByUser(newUserImage.getUser());

--- a/knowlly-core/src/main/resources/application.yml
+++ b/knowlly-core/src/main/resources/application.yml
@@ -47,3 +47,22 @@ server:
       charset: UTF-8
       enabled: true
       force: true
+
+# media
+media:
+  base:
+    dir:
+      name: /home/gradle/mount
+
+cloud:
+  aws:
+    credentials:
+      access_key: CLOUD_AWS_CREDENTIALS_ACCESS_KEY
+      secret_key: CLOUD_AWS_CREDENTIALS_SECRET_KEY
+    s3:
+      bucket: CLOUD_AWS_S3_BUCKET
+    cloudFront :
+      domain : knowllydev-media.hkpark.net
+    domain-uri: https://knowllydev-media.hkpark.net/
+    region:
+      static: ap-northeast-2

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/UserImageRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/UserImageRepositoryTest.java
@@ -1,0 +1,38 @@
+package kr.co.knowledgerally.core.user.repository;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import kr.co.knowledgerally.core.user.util.TestUserImageEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@KnowllyDataTest
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/user_image.xml",
+})
+class UserImageRepositoryTest {
+    @Autowired
+    UserImageRepository userImageRepository;
+
+    TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
+
+    @Test
+    void 사용자로_이미지_목록_찾기() {
+        List<UserImage> userImages = userImageRepository.findAllByUser(testUserEntityFactory.createEntity(1L));
+
+        assertEquals(2, userImages.size());
+        assertEquals(1L, userImages.get(0).getId());
+        assertEquals(2L, userImages.get(1).getId());
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/service/UserImageServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/service/UserImageServiceTest.java
@@ -25,7 +25,7 @@ class UserImageServiceTest {
     TestUserImageEntityFactory testUserImageEntityFactory = new TestUserImageEntityFactory();
 
     @Test
-    @ExpectedDatabase(value = "classpath:dbunit/expected/crud/user_image_insert_test.xml",
+    @ExpectedDatabase(value = "classpath:dbunit/expected/유저_이미지_저장_테스트.xml",
             assertionMode = DatabaseAssertionMode.NON_STRICT)
     void 유저_이미지_저장_테스트() {
         UserImage userImage = testUserImageEntityFactory.createEntity(8L, 1L);

--- a/knowlly-core/src/test/resources/dbunit/expected/유저_이미지_저장_테스트.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/유저_이미지_저장_테스트.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataset>
+    <user_image id="1" user_id="1" user_img_url="http://test1.img.url" is_active="false" />
+    <user_image id="2" user_id="1" user_img_url="http://test1.img2.url" is_active="false" />
+    <user_image id="3" user_id="2" user_img_url="http://test2.img.url" is_active="false" />
+    <user_image id="4" user_id="3" user_img_url="http://test3.img.url" is_active="true" />
+    <user_image id="5" user_id="4" user_img_url="http://test4.img.url" is_active="true" />
+    <user_image id="6" user_id="5" user_img_url="http://test5.img.url" is_active="true" />
+    <user_image id="7" user_id="2" user_img_url="http://test2.img2.url" is_active="true" />
+    <user_image id="8" user_id="1" user_img_url="http://test8.userimg.url" is_active="true" />
+</dataset>


### PR DESCRIPTION
## 작업 내용 설명
- `/api/user/image` 로 post 요청을 통해 Multipart 형식으로 파일을 업로드 할 수 있습니다.
    - 현재 모든 파일이 업로드가 가능하며, 필요시 추후 이미지인지 여부를 검사하는 로직이 필요할 수 있습니다.
- 업로드된 파일은 S3에 저장됩니다.
- 현재 로그인한 사용자의 프로필 이미지 경로를 업데이트 합니다.

## 주요 변경 사항
- 프로필 이미지를 업로드 할 수 있는 엔드포인트가 추가
- S3 업로드 로직 추가
- 관련 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #40

@NaLDo627 @Park-Young-Hun
