### PR TITLE
[기능] 사용자 프로필 조회 추가 (#73)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/component/CoachMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/component/CoachMapper.java
@@ -1,0 +1,17 @@
+package kr.co.knowledgerally.api.coach.component;
+
+import kr.co.knowledgerally.api.coach.dto.CoachDto;
+import kr.co.knowledgerally.api.user.component.UserMapper;
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.user.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = { UserMapper.class })
+public interface CoachMapper {
+    CoachDto.ReadOnly toDto(Coach user);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/dto/CoachDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/dto/CoachDto.java
@@ -1,0 +1,53 @@
+package kr.co.knowledgerally.api.coach.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.Column;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "코치 모델", description = "코치를 나타내는 모델")
+public class CoachDto {
+    @ApiModelProperty(value = "코치 소개", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+            position = PropertyDisplayOrder.INTRODUCE)
+    @JsonProperty(index = PropertyDisplayOrder.INTRODUCE)
+    private String introduce;
+
+    @SuperBuilder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value = "코치 읽기 모델", description = "읽기 전용 코치 모델")
+    public static class ReadOnly extends CoachDto {
+        @ApiModelProperty(value = "코치 고유 아이디", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.ID)
+        @JsonProperty(index = PropertyDisplayOrder.ID)
+        private Long id;
+
+        @ApiModelProperty(value = "사용자 정보", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.USER)
+        @JsonProperty(index = PropertyDisplayOrder.USER)
+        private UserDto.ReadOnly user;
+    }
+
+    private static class PropertyDisplayOrder {
+        private static final int ID = 0;
+        private static final int INTRODUCE = 1;
+        private static final int USER = 2;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserProfileDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserProfileDto.java
@@ -3,6 +3,7 @@ package kr.co.knowledgerally.api.user.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.api.coach.dto.CoachDto;
 import lombok.*;
 
 @Builder
@@ -19,4 +20,8 @@ public class UserProfileDto {
     @ApiModelProperty(value = "프로필 이미지")
     @JsonProperty
     private UserImageDto userImage;
+
+    @ApiModelProperty(value = "코치 정보")
+    @JsonProperty
+    private CoachDto.ReadOnly coach;
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserProfileService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/service/UserProfileService.java
@@ -1,10 +1,16 @@
 package kr.co.knowledgerally.api.user.service;
 
+import kr.co.knowledgerally.api.coach.component.CoachMapper;
 import kr.co.knowledgerally.api.user.component.UserImageMapper;
 import kr.co.knowledgerally.api.user.component.UserMapper;
 import kr.co.knowledgerally.api.user.dto.UserProfileDto;
+import kr.co.knowledgerally.core.coach.service.CoachService;
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import kr.co.knowledgerally.core.core.message.ErrorMessage;
 import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.repository.UserRepository;
 import kr.co.knowledgerally.core.user.service.UserImageService;
+import kr.co.knowledgerally.core.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,13 +25,33 @@ import org.springframework.validation.annotation.Validated;
 public class UserProfileService {
     private final UserMapper userMapper;
     private final UserImageMapper userImageMapper;
+    private final CoachMapper coachMapper;
+    private final UserService userService;
     private final UserImageService userImageService;
+    private final CoachService coachService;
 
-    @Transactional
-    public UserProfileDto getProfile(User loggedInUser) {
+    /**
+     * 사용자 프로필을 조회합니다.
+     * @param userId 조회하고자 하는 사용자 Id
+     * @return 사용자 프로필 dto
+     * @throws ResourceNotFoundException 존재하지 않는 사용자 Id의 경우
+     */
+    @Transactional(readOnly = true)
+    public UserProfileDto getProfile(Long userId) throws ResourceNotFoundException {
+        return getProfile(userService.findById(userId));
+    }
+
+    /**
+     * 사용자 프로필을 조회합니다.
+     * @param user 조회하고자 하는 사용자
+     * @return 사용자 프로필 dto
+     */
+    @Transactional(readOnly = true)
+    public UserProfileDto getProfile(User user) {
         return UserProfileDto.builder()
-                .user(userMapper.toDto(loggedInUser))
-                .userImage(userImageMapper.toDto(userImageService.findByUser(loggedInUser)))
+                .user(userMapper.toDto(user))
+                .userImage(userImageMapper.toDto(userImageService.findByUser(user)))
+                .coach(coachMapper.toDto(coachService.findByUser(user)))
                 .build();
     }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserController.java
@@ -1,0 +1,36 @@
+package kr.co.knowledgerally.api.user.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.core.annotation.CurrentUser;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.user.dto.UserProfileDto;
+import kr.co.knowledgerally.api.user.service.UserProfileService;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+/**
+ * 사용자 정보 관련 엔드포인트
+ */
+@Api(value = "사용자 정보 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+    private final UserProfileService userProfileService;
+
+    @ApiOperation(value = "특정 사용자의 프로필 가져오기", notes = "특정 사용자의 프로필 정보를 가져옵니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "조회 성공"),
+    })
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResult<UserProfileDto>> getUserInfo(@ApiParam(value = "사용자 id", required = true)
+                                                           @PathVariable Long userId) {
+        return ResponseEntity.ok(ApiResult.ok(userProfileService.getProfile(userId)));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/coach/component/CoachMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/coach/component/CoachMapperTest.java
@@ -1,0 +1,34 @@
+package kr.co.knowledgerally.api.coach.component;
+
+import kr.co.knowledgerally.api.coach.dto.CoachDto;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CoachMapperTest {
+    @Autowired
+    CoachMapper coachMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        Coach coach = new TestCoachEntityFactory().createEntity(1L, 1L);
+
+        CoachDto.ReadOnly coachDto = coachMapper.toDto(coach);
+        assertEquals(1L, coachDto.getId());
+        assertEquals("안녕하세요. 테스트1 코치입니다.", coachDto.getIntroduce());
+        assertEquals(1L, coachDto.getUser().getId());
+        assertEquals("테스트1", coachDto.getUser().getUsername());
+        assertEquals(1, coachDto.getUser().getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", coachDto.getUser().getIntro());
+        assertEquals("kakao_test1", coachDto.getUser().getKakaoId());
+        assertEquals("포트폴리오1", coachDto.getUser().getPortfolio());
+        assertEquals("identifier1", coachDto.getUser().getIdentifier());
+        assertFalse(coachDto.getUser().isCoach());
+        assertTrue(coachDto.getUser().isPushActive());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserControllerTest.java
@@ -1,0 +1,56 @@
+package kr.co.knowledgerally.api.user.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserControllerTest extends AbstractControllerTest {
+    private static final String USER_URL = "/api/user/";
+
+    @WithMockKnowllyUser
+    @Test
+    public void 사용자_프로필_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(USER_URL + 1)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.id").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.username").value("테스트1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.intro").value("안녕하세요. 저는 테스트1이라고 합니다."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.kakaoId").value("kakao_test1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.portfolio").value("포트폴리오1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.identifier").value("identifier1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.coach").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.userImage.userImgUrl").value("http://test1.img.url"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.coach.introduce").value("안녕하세요. 테스트1 코치입니다."))
+                .andDo(print());
+    }
+
+    @WithMockKnowllyUser
+    @Test
+    public void 코치가_아닌_사용자_프로필_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(USER_URL + 2)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.id").value(2L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.username").value("테스트2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.intro").value("안녕하세요. 저는 테스트2이라고 합니다."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.kakaoId").value("kakao_test2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.portfolio").value("포트폴리오2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.identifier").value("identifier2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.coach").value(false))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.userImage.userImgUrl").value("http://test2.img2.url"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.coach").isEmpty())
+                .andDo(print());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserMeControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserMeControllerTest.java
@@ -28,7 +28,6 @@ class UserMeControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.kakaoId").value("kakao_test1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.portfolio").value("포트폴리오1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.identifier").value("identifier1"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.coach").value(true))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.userImage.userImgUrl").value("http://test1.img.url"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.coach.introduce").value("안녕하세요. 테스트1 코치입니다."))
                 .andDo(print());

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserMeControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserMeControllerTest.java
@@ -28,7 +28,9 @@ class UserMeControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.kakaoId").value("kakao_test1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.portfolio").value("포트폴리오1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.identifier").value("identifier1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.coach").value(true))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.userImage.userImgUrl").value("http://test1.img.url"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.coach.introduce").value("안녕하세요. 테스트1 코치입니다."))
                 .andDo(print());
     }
 

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/entity/Coach.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/entity/Coach.java
@@ -1,5 +1,6 @@
-package kr.co.knowledgerally.core.user.entity;
+package kr.co.knowledgerally.core.coach.entity;
 
+import kr.co.knowledgerally.core.user.entity.User;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/entity/Review.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/entity/Review.java
@@ -1,5 +1,6 @@
-package kr.co.knowledgerally.core.user.entity;
+package kr.co.knowledgerally.core.coach.entity;
 
+import kr.co.knowledgerally.core.user.entity.User;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/repository/CoachRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/repository/CoachRepository.java
@@ -1,0 +1,17 @@
+package kr.co.knowledgerally.core.coach.repository;
+
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.user.entity.RefreshToken;
+import kr.co.knowledgerally.core.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CoachRepository extends JpaRepository<Coach, Long> {
+    /**
+     * 사용자로 코치 엔티티 찾기
+     * @param user 사용자
+     * @return 코치 엔티티 Optional
+     */
+    Optional<Coach> findByUser(User user);
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/repository/ReviewRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/repository/ReviewRepository.java
@@ -1,6 +1,6 @@
-package kr.co.knowledgerally.core.user.repository;
+package kr.co.knowledgerally.core.coach.repository;
 
-import kr.co.knowledgerally.core.user.entity.Review;
+import kr.co.knowledgerally.core.coach.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/service/CoachService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/service/CoachService.java
@@ -1,0 +1,24 @@
+package kr.co.knowledgerally.core.coach.service;
+
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.repository.CoachRepository;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@Service
+@RequiredArgsConstructor
+public class CoachService {
+    private final CoachRepository coachRepository;
+
+    /**
+     * 사용자 정보로 코치 검색
+     * @param user 사용자
+     * @return 코치 객체, 없다면 null 리턴
+     */
+    public Coach findByUser(User user) {
+        return coachRepository.findByUser(user).orElse(null);
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/entity/LectureInformation.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/entity/LectureInformation.java
@@ -1,6 +1,6 @@
 package kr.co.knowledgerally.core.lecture.entity;
 
-import kr.co.knowledgerally.core.user.entity.Coach;
+import kr.co.knowledgerally.core.coach.entity.Coach;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/entity/Notification.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/entity/Notification.java
@@ -1,6 +1,6 @@
 package kr.co.knowledgerally.core.user.entity;
 
-import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.coach.entity.Coach;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/CoachRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/CoachRepository.java
@@ -1,7 +1,0 @@
-package kr.co.knowledgerally.core.user.repository;
-
-import kr.co.knowledgerally.core.user.entity.Coach;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CoachRepository extends JpaRepository<Coach, Long> {
-}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserImageService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserImageService.java
@@ -41,7 +41,7 @@ public class UserImageService {
     /**
      * 사용자 프로필 이미지 검색
      * @param user 사용자
-     * @return 사용자의 프로필 이미지 객체
+     * @return 사용자의 프로필 이미지 객체, 없다면 null 리턴
      */
     @Transactional
     public UserImage findByUser(User user) {

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/service/UserService.java
@@ -1,6 +1,7 @@
 package kr.co.knowledgerally.core.user.service;
 
 import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import kr.co.knowledgerally.core.core.message.ErrorMessage;
 import kr.co.knowledgerally.core.user.entity.User;
 import kr.co.knowledgerally.core.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,15 +19,43 @@ import static kr.co.knowledgerally.core.core.message.ErrorMessage.NOT_EXIST_USER
 public class UserService {
     private final UserRepository userRepository;
 
+    /**
+     * 사용자를 저장합니다.
+     * @param user 저장하고자 하는 사용자 엔티티
+     * @return 저장된 사용자 엔티티
+     */
     @Transactional
     public User saveUser(@Valid User user) {
         return userRepository.saveAndFlush(user);
     }
 
+    /**
+     * 식별자로 사용자가 존재하는지 검사합니다.
+     * @param identifier 조회하고자 하는 사용자 식별자
+     * @return 사용자 엔티티
+     */
     @Transactional(readOnly = true)
     public boolean isMemberExistByIdentifier(String identifier) { return userRepository.existsByIdentifierAndIsActive(identifier, true); }
 
+    /**
+     * 사용자 프로필을 식별자로 조회합니다.
+     * @param identifier 조회하고자 하는 사용자 식별자
+     * @return 사용자 엔티티
+     * @throws ResourceNotFoundException 존재하지 않는 사용자 Id의 경우
+     */
     @Transactional(readOnly = true)
-    public User findByIdentifier(String identifier) { return userRepository.findByIdentifierAndIsActive(identifier, true)
+    public User findByIdentifier(String identifier) throws ResourceNotFoundException { return userRepository.findByIdentifierAndIsActive(identifier, true)
             .orElseThrow(() -> new ResourceNotFoundException(NOT_EXIST_USER)); }
+
+    /**
+     * 사용자 프로필을 조회합니다.
+     * @param userId 조회하고자 하는 사용자 Id
+     * @return 사용자 엔티티
+     * @throws ResourceNotFoundException 존재하지 않는 사용자 Id의 경우
+     */
+    @Transactional(readOnly = true)
+    public User findById(Long userId) throws ResourceNotFoundException {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.NOT_EXIST_USER));
+    }
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/CoachRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/CoachRepositoryTest.java
@@ -1,0 +1,55 @@
+package kr.co.knowledgerally.core.coach.repository;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.ExpectedDatabase;
+import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
+import kr.co.knowledgerally.core.core.repository.AbstractRepositoryCrudTest;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import liquibase.pro.packaged.T;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KnowllyDataTest
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/coach.xml",
+})
+class CoachRepositoryTest {
+
+    @Autowired
+    CoachRepository coachRepository;
+
+    TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
+
+    @Test
+    void 사용자_정보로_코치_찾기_테스트() {
+        Coach coach = coachRepository.findByUser(testUserEntityFactory.createEntity(1L)).orElseThrow();
+
+        assertEquals(1L, coach.getId());
+        assertEquals("안녕하세요. 테스트1 코치입니다.", coach.getIntroduce());
+        assertTrue(coach.isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getUpdatedAt());
+        assertEquals(1L, coach.getUser().getId());
+        assertEquals("test1@email.com", coach.getUser().getEmail());
+        assertEquals("테스트1", coach.getUser().getUsername());
+        assertEquals(1, coach.getUser().getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", coach.getUser().getIntro());
+        assertEquals("kakao_test1", coach.getUser().getKakaoId());
+        assertEquals("포트폴리오1", coach.getUser().getPortfolio());
+        assertEquals("identifier1", coach.getUser().getIdentifier());
+        assertTrue(coach.getUser().isCoach());
+        assertTrue(coach.getUser().isPushActive());
+        assertTrue(coach.getUser().isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 18, 58), coach.getUser().getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 19, 0), coach.getUser().getUpdatedAt());
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/crud/CoachRepositoryCrudTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/crud/CoachRepositoryCrudTest.java
@@ -1,12 +1,12 @@
-package kr.co.knowledgerally.core.user.repository.crud;
+package kr.co.knowledgerally.core.coach.repository.crud;
 
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.ExpectedDatabase;
 import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
 import kr.co.knowledgerally.core.core.repository.AbstractRepositoryCrudTest;
-import kr.co.knowledgerally.core.user.entity.Coach;
-import kr.co.knowledgerally.core.user.repository.CoachRepository;
-import kr.co.knowledgerally.core.user.util.TestCoachEntityFactory;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.repository.CoachRepository;
+import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -36,6 +36,19 @@ class CoachRepositoryCrudTest extends AbstractRepositoryCrudTest {
         assertTrue(coach.isActive());
         assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getCreatedAt());
         assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getUpdatedAt());
+        assertEquals(1L, coach.getUser().getId());
+        assertEquals("test1@email.com", coach.getUser().getEmail());
+        assertEquals("테스트1", coach.getUser().getUsername());
+        assertEquals(1, coach.getUser().getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", coach.getUser().getIntro());
+        assertEquals("kakao_test1", coach.getUser().getKakaoId());
+        assertEquals("포트폴리오1", coach.getUser().getPortfolio());
+        assertEquals("identifier1", coach.getUser().getIdentifier());
+        assertTrue(coach.getUser().isCoach());
+        assertTrue(coach.getUser().isPushActive());
+        assertTrue(coach.getUser().isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 18, 58), coach.getUser().getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 19, 0), coach.getUser().getUpdatedAt());
     }
 
     @Override

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/crud/ReviewRepositoryCrudTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/crud/ReviewRepositoryCrudTest.java
@@ -1,12 +1,12 @@
-package kr.co.knowledgerally.core.user.repository.crud;
+package kr.co.knowledgerally.core.coach.repository.crud;
 
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.ExpectedDatabase;
 import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
 import kr.co.knowledgerally.core.core.repository.AbstractRepositoryCrudTest;
-import kr.co.knowledgerally.core.user.entity.Review;
-import kr.co.knowledgerally.core.user.repository.ReviewRepository;
-import kr.co.knowledgerally.core.user.util.TestReviewEntityFactory;
+import kr.co.knowledgerally.core.coach.entity.Review;
+import kr.co.knowledgerally.core.coach.repository.ReviewRepository;
+import kr.co.knowledgerally.core.coach.util.TestReviewEntityFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/service/CoachServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/service/CoachServiceTest.java
@@ -1,0 +1,55 @@
+package kr.co.knowledgerally.core.coach.service;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@KnowllyDataTest
+@Import(CoachService.class)
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/coach.xml",
+})
+class CoachServiceTest {
+    @Autowired
+    CoachService coachService;
+
+    TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
+
+    @Test
+    void 사용자_정보로_코치_찾기_테스트() {
+        Coach coach = coachService.findByUser(testUserEntityFactory.createEntity(1L));
+
+        assertEquals(1L, coach.getId());
+        assertEquals("안녕하세요. 테스트1 코치입니다.", coach.getIntroduce());
+        assertTrue(coach.isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getUpdatedAt());
+        assertEquals(1L, coach.getUser().getId());
+        assertEquals("test1@email.com", coach.getUser().getEmail());
+        assertEquals("테스트1", coach.getUser().getUsername());
+        assertEquals(1, coach.getUser().getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", coach.getUser().getIntro());
+        assertEquals("kakao_test1", coach.getUser().getKakaoId());
+        assertEquals("포트폴리오1", coach.getUser().getPortfolio());
+        assertEquals("identifier1", coach.getUser().getIdentifier());
+        assertTrue(coach.getUser().isCoach());
+        assertTrue(coach.getUser().isPushActive());
+        assertTrue(coach.getUser().isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 18, 58), coach.getUser().getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 19, 0), coach.getUser().getUpdatedAt());
+    }
+
+    @Test
+    void 사용자_정보로_코치_찾는데_없으면_null_테스트() {
+        assertNull(coachService.findByUser(testUserEntityFactory.createEntity(2L)));
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/util/TestCoachEntityFactory.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/util/TestCoachEntityFactory.java
@@ -1,8 +1,9 @@
-package kr.co.knowledgerally.core.user.util;
+package kr.co.knowledgerally.core.coach.util;
 
 import kr.co.knowledgerally.core.core.util.TestEntityFactory;
-import kr.co.knowledgerally.core.user.entity.Coach;
+import kr.co.knowledgerally.core.coach.entity.Coach;
 import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
 
 /**
  * 테스트용 코치 엔티티 생성 팩토리

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/util/TestReviewEntityFactory.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/util/TestReviewEntityFactory.java
@@ -1,9 +1,10 @@
-package kr.co.knowledgerally.core.user.util;
+package kr.co.knowledgerally.core.coach.util;
 
 import kr.co.knowledgerally.core.core.util.TestEntityFactory;
-import kr.co.knowledgerally.core.user.entity.Coach;
-import kr.co.knowledgerally.core.user.entity.Review;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.entity.Review;
 import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
 
 /**
  * 테스트용 리뷰 엔티티 생성 팩토리

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/util/TestLectureInformationEntityFactory.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/util/TestLectureInformationEntityFactory.java
@@ -3,8 +3,8 @@ package kr.co.knowledgerally.core.lecture.util;
 import kr.co.knowledgerally.core.core.util.TestEntityFactory;
 import kr.co.knowledgerally.core.lecture.entity.Category;
 import kr.co.knowledgerally.core.lecture.entity.LectureInformation;
-import kr.co.knowledgerally.core.user.entity.Coach;
-import kr.co.knowledgerally.core.user.util.TestCoachEntityFactory;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
 
 /**
  * 테스트용 강의정보 엔티티 생성 팩토리

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/service/UserServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/service/UserServiceTest.java
@@ -65,4 +65,30 @@ class UserServiceTest {
             userService.findByIdentifier("non-exist-identifier");
         });
     }
+
+    @Test
+    void ID로_사용자_찾기() {
+        User user = userService.findById(1L);
+
+        assertEquals(1L, user.getId());
+        assertEquals("test1@email.com", user.getEmail());
+        assertEquals("테스트1", user.getUsername());
+        assertEquals(1, user.getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", user.getIntro());
+        assertEquals("kakao_test1", user.getKakaoId());
+        assertEquals("포트폴리오1", user.getPortfolio());
+        assertEquals("identifier1", user.getIdentifier());
+        assertTrue(user.isCoach());
+        assertTrue(user.isPushActive());
+        assertTrue(user.isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 18, 58), user.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 19, 0), user.getUpdatedAt());
+    }
+
+    @Test
+    void ID로_사용자_찾기_실패() {
+        assertThrows(ResourceNotFoundException.class, () -> {
+            userService.findById(9999L);
+        });
+    }
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/util/TestNotificationEntityFactory.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/util/TestNotificationEntityFactory.java
@@ -1,7 +1,8 @@
 package kr.co.knowledgerally.core.user.util;
 
+import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
 import kr.co.knowledgerally.core.core.util.TestEntityFactory;
-import kr.co.knowledgerally.core.user.entity.Coach;
+import kr.co.knowledgerally.core.coach.entity.Coach;
 import kr.co.knowledgerally.core.user.entity.Notification;
 import kr.co.knowledgerally.core.user.entity.User;
 


### PR DESCRIPTION
## 작업 내용 설명
- 특정 사용자 프로필을 조회 엔드포인트 추가
- 조회시 사용자 정보, 사용자 이미지, 코치 정보가 조회된다.
- 기존에 존재하던 /api/user/me 엔드포인트 응답에도 코치 정보 추가

## 주요 변경 사항
- coach 패키지 추가, 관련 소스 이동
- CoachDto 추가 및 Mapper 추가
- /api/user/{userId} 엔드포인트 추가, 관련 테스트 코드 추가
- UserService에 누락된 Javadoc보완

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #73

@NaLDo627 @Park-Young-Hun
