### PR TITLE
[기능] 볼내역 목록 조회 추가 (#54)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/component/BallHistoryMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/component/BallHistoryMapper.java
@@ -1,0 +1,15 @@
+package kr.co.knowledgerally.api.user.component;
+
+import kr.co.knowledgerally.api.user.dto.BallHistoryDto;
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.core.user.entity.BallHistory;
+import kr.co.knowledgerally.core.user.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface BallHistoryMapper {
+    BallHistoryDto toDto(BallHistory user);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/BallHistoryDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/BallHistoryDto.java
@@ -1,0 +1,39 @@
+package kr.co.knowledgerally.api.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "볼 내역 모델", description = "볼 내역을 나타내는 모델")
+public class BallHistoryDto {
+    @ApiModelProperty(value = "제목", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+            position = PropertyDisplayOrder.TITLE)
+    @JsonProperty(index = PropertyDisplayOrder.TITLE)
+    private String title;
+
+    @ApiModelProperty(value = "내용", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+            position = PropertyDisplayOrder.CONTENT)
+    @JsonProperty(index = PropertyDisplayOrder.CONTENT)
+    private String content;
+
+    @ApiModelProperty(value = "볼 개수", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+            position = PropertyDisplayOrder.COUNT)
+    @JsonProperty(index = PropertyDisplayOrder.COUNT)
+    private int count;
+
+    private static class PropertyDisplayOrder {
+        private static final int TITLE = 0;
+        private static final int CONTENT = 1;
+        private static final int COUNT = 2;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/BallHistoryController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/BallHistoryController.java
@@ -1,0 +1,49 @@
+package kr.co.knowledgerally.api.user.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.core.annotation.CurrentUser;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.user.component.BallHistoryMapper;
+import kr.co.knowledgerally.api.user.dto.BallHistoryDto;
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.api.user.dto.UserProfileDto;
+import kr.co.knowledgerally.api.user.service.UserDropoutService;
+import kr.co.knowledgerally.api.user.service.UserModifyService;
+import kr.co.knowledgerally.api.user.service.UserProfileService;
+import kr.co.knowledgerally.core.core.exception.BadRequestException;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.repository.BallHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 볼 내역 조회 관련 엔드포인트
+ */
+@Api(value = "볼 내역 조회 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ballhistory")
+public class BallHistoryController {
+    private final BallHistoryRepository ballHistoryRepository;
+    private final BallHistoryMapper ballHistoryMapper;
+
+    @ApiOperation(value = "로그인한 사용자의 볼 내역 가져오기", notes = "현재 로그인한 사용자의 볼 내역을 가져옵니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "조회 성공"),
+    })
+    @GetMapping("/me")
+    public ResponseEntity<ApiResult<List<BallHistoryDto>>> getHistories(@ApiIgnore @CurrentUser User loggedInUser) {
+        return ResponseEntity.ok(ApiResult.ok(
+                ballHistoryRepository.findAllByUserOrderByCreatedAtDesc(loggedInUser)
+                        .stream()
+                        .map(ballHistoryMapper::toDto)
+                        .collect(Collectors.toList())
+        ));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/BallHistoryMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/BallHistoryMapperTest.java
@@ -1,0 +1,29 @@
+package kr.co.knowledgerally.api.user.component;
+
+import kr.co.knowledgerally.api.user.dto.BallHistoryDto;
+import kr.co.knowledgerally.api.user.dto.UserImageDto;
+import kr.co.knowledgerally.core.user.entity.BallHistory;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.util.TestBallHistoryEntityFactory;
+import kr.co.knowledgerally.core.user.util.TestUserImageEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class BallHistoryMapperTest {
+    @Autowired
+    BallHistoryMapper ballHistoryMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        BallHistory ballHistory = new TestBallHistoryEntityFactory().createEntity(1L, 1L);
+
+        BallHistoryDto ballHistoryDto = ballHistoryMapper.toDto(ballHistory);
+        assertEquals("테스트1 제목", ballHistoryDto.getTitle());
+        assertEquals("테스트1 내용", ballHistoryDto.getContent());
+        assertEquals(1, ballHistoryDto.getCount());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/BallHistoryControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/BallHistoryControllerTest.java
@@ -1,0 +1,33 @@
+package kr.co.knowledgerally.api.user.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class BallHistoryControllerTest extends AbstractControllerTest {
+    private static final String BALLHISTORY_ME_URL = "/api/ballhistory/me";
+
+    @WithMockKnowllyUser
+    @Test
+    public void 사용자_볼내역_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(BALLHISTORY_ME_URL)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].title").value("수강 클래스"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("영어 수업"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].count").value(-1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].title").value("운영 클래스"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].content").value("프랑스어 수업"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].count").value(1))
+                .andDo(print());
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/BallHistoryRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/user/repository/BallHistoryRepository.java
@@ -1,7 +1,17 @@
 package kr.co.knowledgerally.core.user.repository;
 
 import kr.co.knowledgerally.core.user.entity.BallHistory;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.entity.UserImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BallHistoryRepository extends JpaRepository<BallHistory, Long> {
+    /**
+     * 사용자로 볼 내역을 최신 순으로 찾는다.
+     * @param user 사용자
+     * @return 사용자 볼 내역 목록
+     */
+    List<BallHistory> findAllByUserOrderByCreatedAtDesc(User user);
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/BallHistoryRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/BallHistoryRepositoryTest.java
@@ -1,0 +1,47 @@
+package kr.co.knowledgerally.core.user.repository;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.user.entity.BallHistory;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import liquibase.pro.packaged.T;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@KnowllyDataTest
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/ball_history.xml",
+})
+class BallHistoryRepositoryTest {
+    @Autowired
+    BallHistoryRepository ballHistoryRepository;
+
+    TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
+
+    void 사용자로_볼내역_목록_찾기() {
+        List<BallHistory> ballHistories = ballHistoryRepository.findAllByUserOrderByCreatedAtDesc(
+                testUserEntityFactory.createEntity(1L));
+
+        assertEquals(2L, ballHistories.get(0).getId());
+        assertEquals(1L, ballHistories.get(0).getUser().getId());
+        assertEquals("수강 클래스", ballHistories.get(0).getTitle());
+        assertEquals("영어 수업", ballHistories.get(0).getContent());
+        assertEquals(-1, ballHistories.get(0).getCount());
+        assertTrue(ballHistories.get(0).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 52, 35), ballHistories.get(0).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 52, 36), ballHistories.get(0).getUpdatedAt());
+        assertEquals(1L, ballHistories.get(1).getId());
+        assertEquals(1L, ballHistories.get(1).getUser().getId());
+        assertEquals("운영 클래스", ballHistories.get(1).getTitle());
+        assertEquals("프랑스어 수업", ballHistories.get(1).getContent());
+        assertEquals(1, ballHistories.get(1).getCount());
+        assertTrue(ballHistories.get(1).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 52, 34), ballHistories.get(1).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 52, 35), ballHistories.get(1).getUpdatedAt());
+    }
+}

--- a/knowlly-core/src/test/resources/dbunit/entity/ball_history.xml
+++ b/knowlly-core/src/test/resources/dbunit/entity/ball_history.xml
@@ -3,7 +3,7 @@
     <ball_history id="1" user_id="1" title="운영 클래스" content="프랑스어 수업" count="1" is_active="true"
                   created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
     <ball_history id="2" user_id="1" title="수강 클래스" content="영어 수업" count="-1" is_active="true"
-                  created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
+                  created_at="2022-06-13 21:52:35" updated_at="2022-06-13 21:52:36"/>
     <ball_history id="3" user_id="2" title="온보딩" content="온보딩" count="1" is_active="true"
                   created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
     <ball_history id="4" user_id="2" title="수강 클래스" content="자바 수업" count="-1" is_active="true"

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/ball_history_delete_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/ball_history_delete_test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
     <ball_history id="2" user_id="1" title="수강 클래스" content="영어 수업" count="-1" is_active="true"
-                  created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
+                  created_at="2022-06-13 21:52:35" updated_at="2022-06-13 21:52:36"/>
     <ball_history id="3" user_id="2" title="온보딩" content="온보딩" count="1" is_active="true"
                   created_at="2022-06-13 21:52:34" updated_at="2022-06-13 21:52:35"/>
     <ball_history id="4" user_id="2" title="수강 클래스" content="자바 수업" count="-1" is_active="true"

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/ball_history_update_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/ball_history_update_test.xml
@@ -3,7 +3,7 @@
     <ball_history id="1" user_id="1" title="제목 변경" content="프랑스어 수업" count="1" is_active="true"
                   created_at="2022-06-13 21:52:34" />
     <ball_history id="2" user_id="1" title="수강 클래스" content="영어 수업" count="-1" is_active="true"
-                  created_at="2022-06-13 21:52:34" />
+                  created_at="2022-06-13 21:52:35" />
     <ball_history id="3" user_id="2" title="온보딩" content="온보딩" count="1" is_active="true"
                   created_at="2022-06-13 21:52:34" />
     <ball_history id="4" user_id="2" title="수강 클래스" content="자바 수업" count="-1" is_active="true"

--- a/knowlly-core/src/test/resources/sql/integration.sql
+++ b/knowlly-core/src/test/resources/sql/integration.sql
@@ -13,7 +13,7 @@ INSERT INTO user_image (id, user_id, user_img_url, is_active, created_at, update
 INSERT INTO user_image (id, user_id, user_img_url, is_active, created_at, updated_at) VALUES (7, 2, 'http://test2.img2.url', true, '2022-06-13 21:27:06', '2022-06-13 21:27:06');
 
 INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (1, 1, '운영 클래스', '프랑스어 수업', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
-INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (2, 1, '수강 클래스', '영어 수업', -1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
+INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (2, 1, '수강 클래스', '영어 수업', -1, true, '2022-06-13 21:52:35', '2022-06-13 21:52:36');
 INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (3, 2, '온보딩', '온보딩', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
 INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (4, 2, '수강 클래스', '자바 수업', -1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');
 INSERT INTO ball_history (id, user_id, title, content, count, is_active, created_at, updated_at) VALUES (5, 3, '운영 클래스', '프랑스어 수업', 1, true, '2022-06-13 21:52:34', '2022-06-13 21:52:35');


### PR DESCRIPTION
## 작업 내용 설명
- 로그인한 사용자의 볼 내역을 조회할 수 있다.
- 볼 내역은 createdAt 기준 내림차순 정렬하여 보여진다.
- 이후 페이징이 추가될 수도 있다.

## 주요 변경 사항
- 볼 내역 조회 엔드포인트 추가 (/api/ballhistory/me)
- 관련 서비스 및 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #54 

@NaLDo627 @Park-Young-Hun
