### PR TITLE
[기능] 클래스 카테고리 목록 조회 추가 (#42)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/CategoryMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/CategoryMapper.java
@@ -1,0 +1,13 @@
+package kr.co.knowledgerally.api.lecture.component;
+
+import kr.co.knowledgerally.api.lecture.dto.CategoryDto;
+import kr.co.knowledgerally.core.lecture.entity.Category;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface CategoryMapper {
+    CategoryDto toDto(Category category);
+    Category toEntity(CategoryDto categoryDto);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/CategoryDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/CategoryDto.java
@@ -1,0 +1,25 @@
+package kr.co.knowledgerally.api.lecture.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import javax.validation.constraints.NotBlank;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "카테고리 모델", description = "클래스 카테고리를 나타내는 모델")
+public class CategoryDto {
+    @NotBlank
+    @ApiModelProperty(value = "카테고리 이름", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+    @JsonProperty
+    private String categoryName;
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/web/CategoryController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/web/CategoryController.java
@@ -1,0 +1,45 @@
+package kr.co.knowledgerally.api.lecture.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.lecture.component.CategoryMapper;
+import kr.co.knowledgerally.api.lecture.dto.CategoryDto;
+import kr.co.knowledgerally.core.lecture.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 클래스 카테고리 관련 엔드포인트
+ */
+@Api(value = "클래스 카테고리 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/category")
+public class CategoryController {
+    private final CategoryService categoryService;
+    private final CategoryMapper categoryMapper;
+
+    @ApiOperation(value = "클래스 카테고리", notes = "클래스의 카테고리 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "성공"),
+    })
+    @GetMapping("")
+    public ResponseEntity<ApiResult<List<CategoryDto>>> getAllCategory() {
+        return ResponseEntity.ok(
+                ApiResult.ok(
+                        categoryService.findAll().stream()
+                                .map(x-> categoryMapper.toDto(x))
+                                .collect(Collectors.toList())
+                )
+        );
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/CategoryMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/CategoryMapperTest.java
@@ -1,0 +1,34 @@
+package kr.co.knowledgerally.api.lecture.component;
+
+import kr.co.knowledgerally.api.lecture.dto.CategoryDto;
+import kr.co.knowledgerally.api.lecture.util.TestCategoryDtoFactory;
+import kr.co.knowledgerally.core.lecture.entity.Category;
+import kr.co.knowledgerally.core.lecture.util.TestCategoryEntityFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CategoryMapperTest {
+    @Autowired
+    private CategoryMapper categoryMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        Category category = new TestCategoryEntityFactory().createEntity(1L);
+
+        CategoryDto categoryDto = categoryMapper.toDto(category);
+        assertEquals("테스트 카테고리1", categoryDto.getCategoryName());
+    }
+
+    @Test
+    void DTO에서_엔티티변환_테스트() {
+        CategoryDto categoryDto = new TestCategoryDtoFactory().createDto(1L);
+
+        Category category = categoryMapper.toEntity(categoryDto);
+        assertEquals("테스트 카테고리1", category.getCategoryName());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestCategoryDtoFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestCategoryDtoFactory.java
@@ -1,0 +1,24 @@
+package kr.co.knowledgerally.api.lecture.util;
+
+import kr.co.knowledgerally.api.core.util.TestDtoFactory;
+import kr.co.knowledgerally.api.lecture.dto.CategoryDto;
+import kr.co.knowledgerally.api.user.dto.UserDto;
+
+/**
+ * 테스트용 카테고리 Dto 생성 팩토리
+ */
+public class TestCategoryDtoFactory implements TestDtoFactory<CategoryDto> {
+
+    /**
+     * 테스트용 카테고리 Dto를 생성한다.
+     *
+     * @param id 생성될 Dto Id
+     * @return 생성된 사용자 Dto
+     */
+    @Override
+    public CategoryDto createDto(long id) {
+        return CategoryDto.builder()
+                .categoryName(String.format("테스트 카테고리%d", id))
+                .build();
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CategoryControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CategoryControllerTest.java
@@ -1,0 +1,31 @@
+package kr.co.knowledgerally.api.lecture.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+
+class CategoryControllerTest extends AbstractControllerTest {
+    private static final String CATEGORY_URL = "/api/category";
+
+    @WithMockKnowllyUser
+    @Test
+    public void 카테고리_목록_조회_테스트() throws Exception {
+        mockMvc.perform(
+                get(CATEGORY_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].categoryName").value("기획 / PM"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].categoryName").value("디자인"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[2].categoryName").value("개발"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[3].categoryName").value("마케팅"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[4].categoryName").value("외국어"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[5].categoryName").value("기타"));
+    }
+
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/repository/CategoryRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/repository/CategoryRepository.java
@@ -1,7 +1,17 @@
 package kr.co.knowledgerally.core.lecture.repository;
 
 import kr.co.knowledgerally.core.lecture.entity.Category;
+import kr.co.knowledgerally.core.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    /**
+     * 카테고리를 활성화 여부로 검색
+     * @param isActive 활성화 여부
+     * @return 카테고리 Optional
+     */
+    List<Category> findAllByIsActive(boolean isActive);
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/CategoryService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/CategoryService.java
@@ -1,0 +1,22 @@
+package kr.co.knowledgerally.core.lecture.service;
+
+import kr.co.knowledgerally.core.lecture.entity.Category;
+import kr.co.knowledgerally.core.lecture.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+@Validated
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<Category> findAll() {
+        return categoryRepository.findAllByIsActive(true);
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/CategoryServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/CategoryServiceTest.java
@@ -1,0 +1,39 @@
+package kr.co.knowledgerally.core.lecture.service;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.lecture.entity.Category;
+import kr.co.knowledgerally.core.lecture.util.TestCategoryEntityFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@KnowllyDataTest
+@Import(CategoryService.class)
+@DatabaseSetup({
+        "classpath:dbunit/entity/category.xml",
+})
+class CategoryServiceTest {
+    @Autowired
+    CategoryService categoryService;
+
+    TestCategoryEntityFactory testCategoryEntityFactory = new TestCategoryEntityFactory();
+
+    @Test
+    void IsActive로_카테고리_목록_조회() {
+        List<Category> categoryList = categoryService.findAll();
+
+        assertEquals(categoryList.get(0).getCategoryName(), "기획 / PM");
+        assertEquals(categoryList.get(1).getCategoryName(), "디자인");
+        assertEquals(categoryList.get(2).getCategoryName(), "개발");
+        assertEquals(categoryList.get(3).getCategoryName(), "마케팅");
+        assertEquals(categoryList.get(4).getCategoryName(), "외국어");
+        assertEquals(categoryList.get(5).getCategoryName(), "기타");
+    }
+}


### PR DESCRIPTION
## 작업 내용 설명
- 클래스 카테고리 목록을 조회하여 홈 화면에 보여준다.

## 주요 변경 사항
- 클래스 카테고리 목록 조회 엔드포인트 추가(/api/category)
- 관련 서비스 및 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #42

@NaLDo627 @Park-Young-Hun
