### PR TITLE
[기능] 사용자 설정 (푸시알림) 엔드포인트 추가 (#91)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserSettingController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/web/UserSettingController.java
@@ -1,0 +1,43 @@
+package kr.co.knowledgerally.api.user.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.core.annotation.CurrentUser;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.user.dto.UserProfileDto;
+import kr.co.knowledgerally.api.user.service.UserProfileService;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.service.UserService;
+import lombok.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+/**
+ * 사용자 설정 관련 엔드포인트
+ */
+@Api(value = "사용자 설정 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/setting")
+public class UserSettingController {
+    private final UserService userService;
+
+    @ApiOperation(value = "푸시 알림 설정", notes = "로그인한 사용자의 푸시 알림 수신 여부를 설정합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "수정 성공"),
+    })
+    @PatchMapping("/push")
+    public ResponseEntity<ApiResult<PushSettingDto>> setPush(@ApiIgnore @CurrentUser User loggedInUser,
+                                                             @RequestBody PushSettingDto pushSettingDto) {
+        loggedInUser.setPushActive(pushSettingDto.isPushActive);
+        userService.saveUser(loggedInUser);
+        return ResponseEntity.ok(ApiResult.ok(pushSettingDto));
+    }
+
+    @ApiModel(value = "사용자 푸시 알림 모델", description = "사용자 푸시 알림 설정 여부를 나타내는 모델")
+    @NoArgsConstructor
+    @Getter
+    public static class PushSettingDto {
+        private boolean isPushActive;
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserSettingControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserSettingControllerTest.java
@@ -1,0 +1,34 @@
+package kr.co.knowledgerally.api.user.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserSettingControllerTest  extends AbstractControllerTest {
+    private static final String USER_SETTING_PUSH_URL = "/api/user/setting/push";
+
+    @WithMockKnowllyUser
+    @Test
+    public void 사용자_푸시알림설정_변경_테스트() throws Exception {
+        final String newMemberJsonString =
+                "{" +
+                    "\"pushActive\": false" +
+                "}";
+
+        mockMvc.perform(
+                        patch(USER_SETTING_PUSH_URL)
+                                .content(newMemberJsonString)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.pushActive").value(false))
+                .andDo(print());
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/BallHistoryRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/user/repository/BallHistoryRepositoryTest.java
@@ -5,6 +5,7 @@ import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
 import kr.co.knowledgerally.core.user.entity.BallHistory;
 import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
 import liquibase.pro.packaged.T;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ class BallHistoryRepositoryTest {
 
     TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
 
+    @Test
     void 사용자로_볼내역_목록_찾기() {
         List<BallHistory> ballHistories = ballHistoryRepository.findAllByUserOrderByCreatedAtDesc(
                 testUserEntityFactory.createEntity(1L));


### PR DESCRIPTION
## 작업 내용 설명
- 사용자 설정을 변경할 수 있는 엔드포인트를 추가했다.
    - 현재로서는 push 알림 수신 여부를 설정할 수 있다.

## 주요 변경 사항
- UserSettingController 추가
- 관련 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #91

@NaLDo627 @Park-Young-Hun
