### PR TITLE
[기능] 후기 목록 조회 추가 (#59)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/component/ReviewMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/component/ReviewMapper.java
@@ -1,0 +1,21 @@
+package kr.co.knowledgerally.api.coach.component;
+
+import kr.co.knowledgerally.api.user.component.UserMapper;
+import kr.co.knowledgerally.api.coach.dto.ReviewDto;
+import kr.co.knowledgerally.core.coach.entity.Review;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.time.format.DateTimeFormatter;
+
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        imports = DateTimeFormatter.class,
+        uses = { CoachMapper.class, UserMapper.class })
+public interface ReviewMapper {
+    @Mapping(target = "writtenDate", expression = "java(review.getCreatedAt()" +
+            ".format(DateTimeFormatter.ofPattern(\"yyyy-MM-dd\")) )")
+    @Mapping(target = "isPublic", source = "review.public")
+    ReviewDto.ReadOnly toDto(Review review);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/dto/ReviewDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/dto/ReviewDto.java
@@ -1,0 +1,59 @@
+package kr.co.knowledgerally.api.coach.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "후기 모델", description = "후기를 나타내는 모델")
+public class ReviewDto {
+
+    @ApiModelProperty(value = "내용", position = PropertyDisplayOrder.CONTENT)
+    @JsonProperty(index = PropertyDisplayOrder.CONTENT)
+    private String content;
+
+    @ApiModelProperty(value = "공개 여부", position = PropertyDisplayOrder.IS_PUBLIC)
+    @JsonProperty(index = PropertyDisplayOrder.IS_PUBLIC)
+    private boolean isPublic;
+
+    @SuperBuilder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value = "후기 읽기 모델", description = "읽기 전용 후기 모델")
+    public static class ReadOnly extends ReviewDto {
+        @ApiModelProperty(value = "작성자", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.WRITER)
+        @JsonProperty(index = PropertyDisplayOrder.WRITER)
+        private UserDto.ReadOnly writer;
+
+        @ApiModelProperty(value = "대상 코치", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.REVIEWEE)
+        @JsonProperty(index = PropertyDisplayOrder.REVIEWEE)
+        private CoachDto.ReadOnly reviewee;
+
+        @ApiModelProperty(value = "작성된 날짜", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.WRITTEN_DATE)
+        @JsonProperty(index = PropertyDisplayOrder.WRITTEN_DATE)
+        private String writtenDate;
+    }
+
+    private static class PropertyDisplayOrder {
+        private static final int WRITER = 0;
+        private static final int REVIEWEE = 1;
+        private static final int CONTENT = 2;
+        private static final int IS_PUBLIC = 3;
+        private static final int WRITTEN_DATE = 4;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/service/ReviewUserService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/service/ReviewUserService.java
@@ -1,0 +1,32 @@
+package kr.co.knowledgerally.api.coach.service;
+
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.entity.Review;
+import kr.co.knowledgerally.core.coach.service.CoachService;
+import kr.co.knowledgerally.core.coach.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewUserService {
+    private final ReviewService reviewService;
+    private final CoachService coachService;
+
+    /**
+     * 후기 대상자 Id로 후기를 페이징 해서 찾는다.
+     * @param revieweeId 후기 대상자 userId
+     * @param includePrivate 비공개까지 포함할 지 여부
+     * @param pageable 페이징 객체
+     * @return 후기 페이징 객체
+     */
+    public Page<Review> findAllByRevieweeWithPageable(Long revieweeId, boolean includePrivate, Pageable pageable) {
+        Coach coach = coachService.findById(revieweeId);
+        if (includePrivate) {
+            return reviewService.findAllByRevieweeWithPageable(coach, pageable);
+        }
+        return reviewService.findAllByRevieweeAndIsPublicWithPageable(coach, true, pageable);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/web/ReviewUserController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/web/ReviewUserController.java
@@ -1,0 +1,64 @@
+package kr.co.knowledgerally.api.coach.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.coach.component.ReviewMapper;
+import kr.co.knowledgerally.api.coach.dto.ReviewDto;
+import kr.co.knowledgerally.api.coach.service.ReviewUserService;
+import kr.co.knowledgerally.api.core.annotation.CurrentUser;
+import kr.co.knowledgerally.api.core.dto.ApiPageRequest;
+import kr.co.knowledgerally.api.core.dto.ApiPageResult;
+import kr.co.knowledgerally.core.coach.service.ReviewService;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+/**
+ * 리뷰 관련 엔드포인트
+ */
+@Api(value = "리뷰 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/review")
+public class ReviewUserController {
+    private final ReviewUserService reviewUserService;
+    private final ReviewMapper reviewMapper;
+
+    @ApiOperation(value = "특정 사용자의 리뷰 가져오기", notes = "특정 사용자의 리뷰 목록을 가져옵니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "조회 성공"),
+    })
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<ApiPageResult<ReviewDto.ReadOnly>> getReviews(@ApiParam(value = "사용자 id", required = true)
+                                                                        @PathVariable
+                                                                        Long userId,
+                                                                        @ApiParam(value = "비공개된 리뷰까지 모두 가져올 것인지",
+                                                                                defaultValue = "false")
+                                                                        @RequestParam(value = "include_private",
+                                                                                required = false,
+                                                                                defaultValue = "false")
+                                                                        boolean includePrivate,
+                                                                        ApiPageRequest pageRequest) {
+        return ResponseEntity.ok(ApiPageResult.ok(
+                reviewUserService.findAllByRevieweeWithPageable(userId, includePrivate, pageRequest.convert())
+                        .map(reviewMapper::toDto)));
+    }
+
+    @ApiOperation(value = "로그인한 사용자의 리뷰 가져오기", notes = "로그인한 사용자의 리뷰 목록을 가져옵니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "조회 성공"),
+    })
+    @GetMapping("/user/me")
+    public ResponseEntity<ApiPageResult<ReviewDto.ReadOnly>> getMyReviews(@ApiParam(value = "비공개된 리뷰까지 모두 가져올 것인지", defaultValue = "true")
+                                                                          @RequestParam(value = "include_private",
+                                                                                  required = false,
+                                                                                  defaultValue = "true")
+                                                                          boolean includePrivate,
+                                                                          ApiPageRequest pageRequest,
+                                                                          @ApiIgnore @CurrentUser User loggedInUser) {
+        return ResponseEntity.ok(ApiPageResult.ok(
+                reviewUserService.findAllByRevieweeWithPageable(loggedInUser.getId(), includePrivate, pageRequest.convert())
+                        .map(reviewMapper::toDto)));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/coach/component/ReviewMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/coach/component/ReviewMapperTest.java
@@ -1,0 +1,29 @@
+package kr.co.knowledgerally.api.coach.component;
+
+import kr.co.knowledgerally.api.coach.component.ReviewMapper;
+import kr.co.knowledgerally.api.coach.dto.ReviewDto;
+import kr.co.knowledgerally.core.coach.entity.Review;
+import kr.co.knowledgerally.core.coach.util.TestReviewEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+class ReviewMapperTest {
+    @Autowired
+    ReviewMapper reviewMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        Review review = new TestReviewEntityFactory().createEntity(1L, 1L, 2L);
+
+        ReviewDto.ReadOnly reviewDto = reviewMapper.toDto(review);
+        assertEquals(1L, reviewDto.getWriter().getId());
+        assertEquals(2L, reviewDto.getReviewee().getId());
+        assertTrue(reviewDto.isPublic());
+        assertEquals("테스트1 내용", reviewDto.getContent());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/coach/web/ReviewUserControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/coach/web/ReviewUserControllerTest.java
@@ -1,0 +1,108 @@
+package kr.co.knowledgerally.api.coach.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReviewUserControllerTest extends AbstractControllerTest {
+    private static final String REVIEW_USER_URL = "/api/review/user/";
+    private static final String REVIEW_USER_ME_URL = "/api/review/user/me";
+
+    @WithMockKnowllyUser
+    @Test
+    public void 사용자_리뷰_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(REVIEW_USER_URL + 3)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .param("include_private", "false")
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].writer.username").value("테스트1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].reviewee.id").value(3))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("테스트3은 좋은 코치입니다!"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].public").value(true))
+                //   .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].writtenDate").value("2022-06-13")) // TODO CI/CD 러너 환경 타임존 세팅
+                .andExpect(MockMvcResultMatchers.jsonPath("$.totalPage").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.totalElements").value(1))
+                .andDo(print());
+    }
+
+    @WithMockKnowllyUser
+    @Test
+    public void 사용자_리뷰_전체_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(REVIEW_USER_URL + 3)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .param("include_private", "true")
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].writer.username").value("테스트4"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].reviewee.id").value(3))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("테스트3 코치는 좀 별로였습니다"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].public").value(false))
+                // .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].writtenDate").value("2022-06-13"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].writer.username").value("테스트1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].reviewee.id").value(3))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].content").value("테스트3은 좋은 코치입니다!"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].public").value(true))
+                //   .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].writtenDate").value("2022-06-13"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.totalPage").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.totalElements").value(2))
+                .andDo(print());
+    }
+
+    @WithMockKnowllyUser
+    @Test
+    public void 로그인된_사용자_리뷰_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(REVIEW_USER_ME_URL)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .param("include_private", "false")
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].writer.username").value("테스트3"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].reviewee.id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("테스트1 코치가 최고에요~"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].public").value(true))
+                // .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].writtenDate").value("2022-06-13"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].writer.username").value("테스트2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].reviewee.id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].content").value("테스트1 코치는 친절했어요~"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].public").value(true))
+                //   .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].writtenDate").value("2022-06-13"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.totalPage").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.totalElements").value(2))
+                .andDo(print());
+    }
+
+    @WithMockKnowllyUser
+    @Test
+    public void 로그인된_사용자_리뷰_전체_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(REVIEW_USER_ME_URL)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .param("include_private", "true")
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("ok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].writer.username").value("테스트3"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].reviewee.id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("테스트1 코치가 최고에요~"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].public").value(true))
+                // .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].writtenDate").value("2022-06-13"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].writer.username").value("테스트2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].reviewee.id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].content").value("테스트1 코치는 친절했어요~"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].public").value(true))
+                //   .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].writtenDate").value("2022-06-13"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.totalPage").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.totalElements").value(2))
+                .andDo(print());
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/entity/Review.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/entity/Review.java
@@ -22,11 +22,11 @@ public class Review {
 
     @OneToOne
     @JoinColumn(name = "user_id")
-    private User user;
+    private User writer;
 
     @OneToOne
     @JoinColumn(name = "coach_id")
-    private Coach coach;
+    private Coach reviewee;
 
     @Column(nullable = false)
     private String content;

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/repository/ReviewRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/repository/ReviewRepository.java
@@ -1,7 +1,28 @@
 package kr.co.knowledgerally.core.coach.repository;
 
+import kr.co.knowledgerally.core.coach.entity.Coach;
 import kr.co.knowledgerally.core.coach.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    /**
+     * 후기 페이징 조회
+     * @param reviewee 리뷰 대상자
+     * @param isActive 활성화 여부
+     * @param pageable 페이징 요청 객체
+     * @return 후기 객체 페이징
+     */
+    Page<Review> findAllByRevieweeAndIsActiveOrderByCreatedAtDesc(Coach reviewee, boolean isActive, Pageable pageable);
+
+    /**
+     * 후기 페이징 조회
+     * @param reviewee 리뷰 대상자
+     * @param isPublic 공개 여부
+     * @param isActive 페이징 요청 객체
+     * @param pageable 페이징 요청 객체
+     * @return 후기 객체 페이징
+     */
+    Page<Review> findAllByRevieweeAndIsPublicAndIsActiveOrderByCreatedAtDesc(Coach reviewee, boolean isPublic, boolean isActive, Pageable pageable);
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/service/CoachService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/service/CoachService.java
@@ -2,9 +2,12 @@ package kr.co.knowledgerally.core.coach.service;
 
 import kr.co.knowledgerally.core.coach.entity.Coach;
 import kr.co.knowledgerally.core.coach.repository.CoachRepository;
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import kr.co.knowledgerally.core.core.message.ErrorMessage;
 import kr.co.knowledgerally.core.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 @Validated
@@ -20,5 +23,17 @@ public class CoachService {
      */
     public Coach findByUser(User user) {
         return coachRepository.findByUser(user).orElse(null);
+    }
+
+    /**
+     * 코치 프로필을 조회합니다.
+     * @param coachId 조회하고자 하는 코치 Id
+     * @return 코치 엔티티
+     * @throws ResourceNotFoundException 존재하지 않는 사용자 Id의 경우
+     */
+    @Transactional(readOnly = true)
+    public Coach findById(Long coachId) throws ResourceNotFoundException {
+        return coachRepository.findById(coachId)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.NOT_EXIST_COACH));
     }
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/service/ReviewService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/coach/service/ReviewService.java
@@ -1,0 +1,41 @@
+package kr.co.knowledgerally.core.coach.service;
+
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.entity.Review;
+import kr.co.knowledgerally.core.coach.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+
+    /**
+     * 후기 대상자로 후기를 페이징 해서 찾는다.
+     * @param reviewee 후기 대상자
+     * @param pageable 페이징 요청 객체
+     * @return 후기 객체 페이징
+     */
+    @Transactional(readOnly = true)
+    public Page<Review> findAllByRevieweeWithPageable(Coach reviewee, Pageable pageable) {
+        return reviewRepository.findAllByRevieweeAndIsActiveOrderByCreatedAtDesc(reviewee, true, pageable);
+    }
+
+    /**
+     * 작성자로 후기를 페이징 해서 찾는다.
+     * @param reviewee 후기 대상자
+     * @param isPublic 공개 여부
+     * @param pageable 페이징 요청 객체
+     * @return 후기 객체 페이징
+     */
+    @Transactional(readOnly = true)
+    public Page<Review> findAllByRevieweeAndIsPublicWithPageable(Coach reviewee, boolean isPublic, Pageable pageable) {
+        return reviewRepository.findAllByRevieweeAndIsPublicAndIsActiveOrderByCreatedAtDesc(reviewee, isPublic, true, pageable);
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ErrorMessage.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ErrorMessage.java
@@ -9,4 +9,5 @@ public class ErrorMessage {
 
     // Member
     public static String NOT_EXIST_USER = "존재하지 않는 사용자입니다.";
+    public static String NOT_EXIST_COACH = "존재하지 않는 코치입니다.";
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/CoachRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/CoachRepositoryTest.java
@@ -52,4 +52,28 @@ class CoachRepositoryTest {
         assertEquals(LocalDateTime.of(2022, 6, 10, 21, 18, 58), coach.getUser().getCreatedAt());
         assertEquals(LocalDateTime.of(2022, 6, 10, 21, 19, 0), coach.getUser().getUpdatedAt());
     }
+
+    @Test
+    void 사용자_ID로_코치_찾기_테스트() {
+        Coach coach = coachRepository.findById(1L).orElseThrow();
+
+        assertEquals(1L, coach.getId());
+        assertEquals("안녕하세요. 테스트1 코치입니다.", coach.getIntroduce());
+        assertTrue(coach.isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getUpdatedAt());
+        assertEquals(1L, coach.getUser().getId());
+        assertEquals("test1@email.com", coach.getUser().getEmail());
+        assertEquals("테스트1", coach.getUser().getUsername());
+        assertEquals(1, coach.getUser().getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", coach.getUser().getIntro());
+        assertEquals("kakao_test1", coach.getUser().getKakaoId());
+        assertEquals("포트폴리오1", coach.getUser().getPortfolio());
+        assertEquals("identifier1", coach.getUser().getIdentifier());
+        assertTrue(coach.getUser().isCoach());
+        assertTrue(coach.getUser().isPushActive());
+        assertTrue(coach.getUser().isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 18, 58), coach.getUser().getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 19, 0), coach.getUser().getUpdatedAt());
+    }
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/ReviewRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/ReviewRepositoryTest.java
@@ -1,0 +1,54 @@
+package kr.co.knowledgerally.core.coach.repository;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.coach.entity.Review;
+import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@KnowllyDataTest
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/coach.xml",
+        "classpath:dbunit/entity/review.xml",
+})
+class ReviewRepositoryTest {
+    @Autowired
+    ReviewRepository reviewRepository;
+
+    TestCoachEntityFactory testCoachEntityFactory = new TestCoachEntityFactory();
+
+    @Test
+    void 후기_대상자로_후기_찾기_페이징_테스트() {
+        Page<Review> reviews = reviewRepository.findAllByRevieweeAndIsActiveOrderByCreatedAtDesc(
+                testCoachEntityFactory.createEntity(3L, 3L), true, PageRequest.of(0, 2));
+
+        assertEquals(2, reviews.getNumberOfElements());
+        assertEquals(2, reviews.getTotalElements());
+        assertEquals(0, reviews.getPageable().getPageNumber());
+        assertEquals(2, reviews.getPageable().getPageSize());
+        assertEquals(1, reviews.getTotalPages());
+        assertEquals(2, reviews.getContent().size());
+        assertEquals("테스트3 코치는 좀 별로였습니다", reviews.getContent().get(0).getContent());
+        assertEquals("테스트3은 좋은 코치입니다!", reviews.getContent().get(1).getContent());
+    }
+
+    @Test
+    void 후기_대상자로_후기_찾기_공개여부_포함_페이징_테스트() {
+        Page<Review> reviews = reviewRepository.findAllByRevieweeAndIsPublicAndIsActiveOrderByCreatedAtDesc(
+                testCoachEntityFactory.createEntity(3L, 3L), false, true, PageRequest.of(0, 2));
+
+        assertEquals(1, reviews.getNumberOfElements());
+        assertEquals(1, reviews.getTotalElements());
+        assertEquals(0, reviews.getPageable().getPageNumber());
+        assertEquals(2, reviews.getPageable().getPageSize());
+        assertEquals(1, reviews.getTotalPages());
+        assertEquals(1, reviews.getContent().size());
+        assertEquals("테스트3 코치는 좀 별로였습니다", reviews.getContent().get(0).getContent());
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/crud/ReviewRepositoryCrudTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/repository/crud/ReviewRepositoryCrudTest.java
@@ -32,9 +32,9 @@ class ReviewRepositoryCrudTest extends AbstractRepositoryCrudTest {
         Review review = reviewRepository.findById(1L).orElseThrow();
 
         assertEquals(1L, review.getId());
-        assertEquals(1L, review.getUser().getId());
-        assertEquals(3L, review.getCoach().getId());
-        assertEquals(4L, review.getCoach().getUser().getId());
+        assertEquals(1L, review.getWriter().getId());
+        assertEquals(3L, review.getReviewee().getId());
+        assertEquals(4L, review.getReviewee().getUser().getId());
         assertEquals("테스트3은 좋은 코치입니다!", review.getContent());
         assertTrue(review.isActive());
         assertEquals(LocalDateTime.of(2022, 6, 13, 22, 19, 14), review.getCreatedAt());

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/service/CoachServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/service/CoachServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.knowledgerally.core.coach.service;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
 import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
 import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,5 +52,36 @@ class CoachServiceTest {
     @Test
     void 사용자_정보로_코치_찾는데_없으면_null_테스트() {
         assertNull(coachService.findByUser(testUserEntityFactory.createEntity(2L)));
+    }
+
+    @Test
+    void 사용자_ID로_코치_찾기_테스트() {
+        Coach coach = coachService.findById(1L);
+
+        assertEquals(1L, coach.getId());
+        assertEquals("안녕하세요. 테스트1 코치입니다.", coach.getIntroduce());
+        assertTrue(coach.isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 21, 57, 17), coach.getUpdatedAt());
+        assertEquals(1L, coach.getUser().getId());
+        assertEquals("test1@email.com", coach.getUser().getEmail());
+        assertEquals("테스트1", coach.getUser().getUsername());
+        assertEquals(1, coach.getUser().getBallCnt());
+        assertEquals("안녕하세요. 저는 테스트1이라고 합니다.", coach.getUser().getIntro());
+        assertEquals("kakao_test1", coach.getUser().getKakaoId());
+        assertEquals("포트폴리오1", coach.getUser().getPortfolio());
+        assertEquals("identifier1", coach.getUser().getIdentifier());
+        assertTrue(coach.getUser().isCoach());
+        assertTrue(coach.getUser().isPushActive());
+        assertTrue(coach.getUser().isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 18, 58), coach.getUser().getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 10, 21, 19, 0), coach.getUser().getUpdatedAt());
+    }
+
+    @Test
+    void 사용자_ID로_코치_찾는데_없으면_throw_테스트() {
+        assertThrows(ResourceNotFoundException.class, () -> {
+            coachService.findById(9999L);
+        });
     }
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/service/ReviewServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/service/ReviewServiceTest.java
@@ -1,0 +1,52 @@
+package kr.co.knowledgerally.core.coach.service;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.coach.entity.Review;
+import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@KnowllyDataTest
+@Import(ReviewService.class)
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/coach.xml",
+        "classpath:dbunit/entity/review.xml",
+})
+class ReviewServiceTest {
+    @Autowired
+    ReviewService reviewService;
+
+    TestCoachEntityFactory testCoachEntityFactory = new TestCoachEntityFactory();
+
+    @Test
+    void 후기_대상자로_후기_찾기_페이징_테스트() {
+        Page<Review> reviews = reviewService.findAllByRevieweeWithPageable(
+                testCoachEntityFactory.createEntity(3L, 3L), PageRequest.of(0, 2));
+
+        assertEquals(2, reviews.getNumberOfElements());
+        assertEquals(2, reviews.getTotalElements());
+        assertEquals(1, reviews.getTotalPages());
+        assertEquals(2, reviews.getContent().size());
+        assertEquals("테스트3 코치는 좀 별로였습니다", reviews.getContent().get(0).getContent());
+        assertEquals("테스트3은 좋은 코치입니다!", reviews.getContent().get(1).getContent());
+    }
+
+    @Test
+    void 후기_대상자로_후기_찾기_공개여부_포함_페이징_테스트() {
+        Page<Review> reviews = reviewService.findAllByRevieweeAndIsPublicWithPageable(
+                testCoachEntityFactory.createEntity(3L, 3L), false, PageRequest.of(0, 2));
+
+        assertEquals(1, reviews.getNumberOfElements());
+        assertEquals(1, reviews.getTotalElements());
+        assertEquals(1, reviews.getTotalPages());
+        assertEquals(1, reviews.getContent().size());
+        assertEquals("테스트3 코치는 좀 별로였습니다", reviews.getContent().get(0).getContent());
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/util/TestReviewEntityFactory.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/coach/util/TestReviewEntityFactory.java
@@ -35,8 +35,8 @@ public class TestReviewEntityFactory implements TestEntityFactory<Review> {
     public Review createEntity(long entityId, long userId, long coachId) {
         return Review.builder()
                 .id(entityId)
-                .user(testUserEntityFactory.createEntity(userId))
-                .coach(testCoachEntityFactory.createEntity(coachId))
+                .writer(testUserEntityFactory.createEntity(userId))
+                .reviewee(testCoachEntityFactory.createEntity(coachId))
                 .content(String.format("테스트%d 내용", entityId))
                 .build();
     }


### PR DESCRIPTION
## 작업 내용 설명
- 특정 사용자 혹은 로그인한 사용자의 후기를 조회할 수 있다.
- parameter를 통해 비공개 후기까지 가져올 수 있다.

## 주요 변경 사항
- 특정 사용자 후기 조회 엔드포인트 추가
- 로그인된 사용자의 후기 조회 엔드포인트 추가
- 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #59 

@NaLDo627 @Park-Young-Hun
