### PR TITLE
[기능] AwsCloudWatch로 로그 전송 추가 (#29)

### DIFF
--- a/.github/workflows/api-test-and-deploy-dev.yml
+++ b/.github/workflows/api-test-and-deploy-dev.yml
@@ -120,6 +120,9 @@ jobs:
 
       - name: 환경변수 치환 후 최종 배포 파일 생성
         uses: danielr1996/envsubst-action@1.0.0
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
           input: deployment/deployment-dev.yml
           output: deploy.yml

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ subprojects {
 		implementation 'org.mapstruct:mapstruct:1.4.2.Final'
 		implementation 'org.liquibase:liquibase-core:4.3.5'
 		annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
+		implementation 'ca.pjer:logback-awslogs-appender:1.4.0'
 	}
 
 	test {

--- a/deployment/deployment-dev.yml
+++ b/deployment/deployment-dev.yml
@@ -33,3 +33,11 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "dev"
+            - name: AWS_ACCESS_KEY_ID
+              value: "$AWS_ACCESS_KEY_ID"
+            - name: AWS_SECRET_ACCESS_KEY
+              value: "$AWS_SECRET_ACCESS_KEY"
+            - name: AWS_ACCESS_KEY
+              value: "$AWS_ACCESS_KEY_ID"
+            - name: AWS_SECRET_KEY
+              value: "$AWS_SECRET_ACCESS_KEY"

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/RequestLogFilter.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/RequestLogFilter.java
@@ -20,7 +20,6 @@ import java.util.Map;
  *  <a href="https://velog.io/@sixhustle/log">소스코드 출처</a>
  */
 @Slf4j
-@WebFilter(urlPatterns= "/api/*")
 public class RequestLogFilter implements Filter {
 
     @Override

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/RequestLogFilter.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/component/RequestLogFilter.java
@@ -1,0 +1,88 @@
+package kr.co.knowledgerally.api.core.component;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+import org.springframework.web.util.WebUtils;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *  <a href="https://velog.io/@sixhustle/log">소스코드 출처</a>
+ */
+@Slf4j
+@WebFilter(urlPatterns= "/api/*")
+public class RequestLogFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper((HttpServletRequest) request);
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper((HttpServletResponse) response);
+
+        long start = System.currentTimeMillis();
+        chain.doFilter(requestWrapper, responseWrapper);
+        long end = System.currentTimeMillis();
+
+        log.info("\n" +
+                        "[REQUEST] {} - {} {} - {}\n" +
+                        "Headers : {}\n" +
+                        "Request : {}\n" +
+                        "Response : {}\n",
+                ((HttpServletRequest) request).getMethod(),
+                ((HttpServletRequest) request).getRequestURI(),
+                responseWrapper.getStatus(),
+                (end - start) / 1000.0,
+                getHeaders((HttpServletRequest) request),
+                getRequestBody(requestWrapper),
+                getResponseBody(responseWrapper));
+    }
+
+    private Map<String, Object> getHeaders(HttpServletRequest request) {
+        Map<String, Object> headerMap = new HashMap<>();
+
+        Enumeration<String> headerArray = request.getHeaderNames();
+        while (headerArray.hasMoreElements()) {
+            String headerName = headerArray.nextElement();
+            headerMap.put(headerName, request.getHeader(headerName));
+        }
+        return headerMap;
+    }
+
+    private String getRequestBody(ContentCachingRequestWrapper request) {
+        ContentCachingRequestWrapper wrapper = WebUtils.getNativeRequest(request, ContentCachingRequestWrapper.class);
+        if (wrapper != null) {
+            byte[] buf = wrapper.getContentAsByteArray();
+            if (buf.length > 0) {
+                try {
+                    return new String(buf, 0, buf.length, wrapper.getCharacterEncoding());
+                } catch (UnsupportedEncodingException e) {
+                    return " - ";
+                }
+            }
+        }
+        return " - ";
+    }
+
+    private String getResponseBody(final HttpServletResponse response) throws IOException {
+        String payload = null;
+        ContentCachingResponseWrapper wrapper =
+                WebUtils.getNativeResponse(response, ContentCachingResponseWrapper.class);
+        if (wrapper != null) {
+            byte[] buf = wrapper.getContentAsByteArray();
+            if (buf.length > 0) {
+                payload = new String(buf, 0, buf.length, wrapper.getCharacterEncoding());
+                wrapper.copyBodyToResponse();
+            }
+        }
+        return null == payload ? " - " : payload;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/WebConfig.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/WebConfig.java
@@ -1,5 +1,8 @@
 package kr.co.knowledgerally.api.core.config;
 
+import kr.co.knowledgerally.api.core.component.RequestLogFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -12,5 +15,15 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins("*")
                 .allowedMethods("*")
                 .maxAge(3000);
+    }
+
+    @Bean
+    public FilterRegistrationBean<RequestLogFilter> requestLogFilter(){
+        FilterRegistrationBean<RequestLogFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new RequestLogFilter());
+        registrationBean.addUrlPatterns("/api/*");
+        registrationBean.setOrder(1);
+        registrationBean.setName("request-log-filter");
+        return registrationBean;
     }
 }

--- a/knowlly-core/src/main/resources/logback-spring.xml
+++ b/knowlly-core/src/main/resources/logback-spring.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- Timestamp used into the Log Stream Name -->
+    <timestamp key="timestamp" datePattern="yyyy-MM-dd-HH-mm-ssSSS"/>
+
+    <!-- The actual AwsLogsAppender (asynchronous mode because of maxFlushTimeMillis > 0) -->
+    <appender name="KNOWLLY_DEV_LOGS" class="ca.pjer.logback.AwsLogsAppender">
+
+        <!-- Send only ERROR and above -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
+        <!-- Nice layout pattern -->
+        <layout>
+            <pattern>[%date] [%level] [%logger{10} %file:%line] %msg%n</pattern>
+        </layout>
+
+        <!-- Hardcoded Log Group Name -->
+        <logGroupName>knowlly-dev-log</logGroupName>
+
+        <!-- Log Stream Name UUID Prefix -->
+        <logStreamUuidPrefix>knowlly-dev/</logStreamUuidPrefix>
+
+        <!-- AWS Region -->
+        <logRegion>ap-northeast-2</logRegion>
+
+        <!-- Maximum number of events in each batch (50 is the default) -->
+        <!-- will flush when the event queue has 50 elements, even if still in quiet time (see maxFlushTimeMillis) -->
+        <maxBatchLogEvents>50</maxBatchLogEvents>
+
+        <!-- Maximum quiet time in millisecond (0 is the default) -->
+        <!-- will flush when met, even if the batch size is not met (see maxBatchLogEvents) -->
+        <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+
+        <!-- Maximum block time in millisecond (5000 is the default) -->
+        <!-- when > 0: this is the maximum time the logging thread will wait for the logger, -->
+        <!-- when == 0: the logging thread will never wait for the logger, discarding events while the queue is full -->
+        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+
+        <!-- Retention value for log groups, 0 for infinite see -->
+        <!-- https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html for other -->
+        <!-- possible values -->
+
+        <retentionTimeDays>0</retentionTimeDays>
+    </appender>
+
+    <!-- A console output -->
+    <appender name="COLOR" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%date] %highlight([%level]) [%logger{10} %file:%line] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Root with a threshold to INFO and above -->
+    <root level="INFO">
+        <appender-ref ref="COLOR"/>
+
+        <springProfile name="dev">
+            <appender-ref ref="COLOR"/>
+            <appender-ref ref="KNOWLLY_DEV_LOGS"/>
+        </springProfile>
+    </root>
+</configuration>


### PR DESCRIPTION
## 작업 내용 설명
- AWS CloudWatch로 로그 전송 로직 추가하여 모니터링을 가능하게 함
- URL Request 로깅 필터 추가하여 상세한 요청 및 응답을 확인할 수 있도록 함

## 주요 변경 사항
- logback 설정 추가하여, AWS CloudWatch로 로그 전송 로직 추가
- Request Logging 추가
- Github Action Workflow 및 Secret 업데이트

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #29 
- resolved #74 

@NaLDo627 @Park-Young-Hun
