### PR TITLE
[기능] 클래스 일정 등록 기능 추가 (#58)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/DateTimeStringValidator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/DateTimeStringValidator.java
@@ -1,0 +1,26 @@
+package kr.co.knowledgerally.api.core.validation;
+
+import kr.co.knowledgerally.api.core.validation.annotation.DateFormat;
+import kr.co.knowledgerally.api.core.validation.annotation.DateTimeFormat;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * yyyy-mm-dd HH:mm:ss 형태의 문자열 유효성 검증
+ */
+public class DateTimeStringValidator implements ConstraintValidator<DateTimeFormat, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        try {
+            LocalDateTime.parse(value,
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/annotation/DateTimeFormat.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/validation/annotation/DateTimeFormat.java
@@ -1,0 +1,25 @@
+package kr.co.knowledgerally.api.core.validation.annotation;
+
+import kr.co.knowledgerally.api.core.validation.DateStringValidator;
+import kr.co.knowledgerally.api.core.validation.DateTimeStringValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = DateTimeStringValidator.class)
+@Documented
+public @interface DateTimeFormat {
+    String message() default "Date format should be like yyyy-MM-dd HH:mm:ss";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/LectureMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/LectureMapper.java
@@ -1,0 +1,32 @@
+package kr.co.knowledgerally.api.lecture.component;
+
+import kr.co.knowledgerally.api.coach.component.CoachMapper;
+import kr.co.knowledgerally.api.lecture.dto.LectureDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureInformationDto;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import kr.co.knowledgerally.core.lecture.entity.LectureInformation;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        imports = {DateTimeFormatter.class, LocalDateTime.class}
+)
+public interface LectureMapper {
+    @Mapping(target = "startAt", expression = "java(lecture.getStartAt()" +
+            ".format(DateTimeFormatter.ofPattern(\"yyyy-MM-dd HH:mm:ss\")) )")
+    @Mapping(target = "endAt", expression = "java(lecture.getEndAt()" +
+            ".format(DateTimeFormatter.ofPattern(\"yyyy-MM-dd HH:mm:ss\")) )")
+    LectureDto.ReadOnly toDto(Lecture lecture);
+
+    @Mapping(target = "startAt", expression = "java(LocalDateTime.parse(lectureDto.getStartAt()" +
+            ", DateTimeFormatter.ofPattern(\"yyyy-MM-dd HH:mm:ss\")) )")
+    @Mapping(target = "endAt", expression = "java(LocalDateTime.parse(lectureDto.getEndAt()" +
+            ", DateTimeFormatter.ofPattern(\"yyyy-MM-dd HH:mm:ss\")) )")
+    Lecture toEntity(LectureDto lectureDto);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/LectureDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/LectureDto.java
@@ -1,0 +1,79 @@
+package kr.co.knowledgerally.api.lecture.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.api.coach.dto.CoachDto;
+import kr.co.knowledgerally.api.core.validation.annotation.DateFormat;
+import kr.co.knowledgerally.api.core.validation.annotation.DateTimeFormat;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "클래스 일정 모델", description = "클래스 일정을 나타내는 모델")
+public class LectureDto {
+
+    @DateTimeFormat
+    @ApiModelProperty(value = "클래스 일정 시작 시간, 형식 yyyy-MM-dd HH:mm:ss", position = PropertyDisplayOrder.START_AT)
+    @JsonProperty(index = PropertyDisplayOrder.START_AT)
+    private String startAt;
+
+    @DateTimeFormat
+    @ApiModelProperty(value = "클래스 일정 종료 시간, 형식 yyyy-MM-dd HH:mm:ss", position = PropertyDisplayOrder.END_AT)
+    @JsonProperty(index = PropertyDisplayOrder.END_AT)
+    private String endAt;
+
+    @SuperBuilder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value = "클래스 일정 읽기 모델", description = "읽기 전용 클래스 일정 모델")
+    public static class ReadOnly extends LectureDto {
+        @ApiModelProperty(
+                value = "클래스 일정 id",
+                position = PropertyDisplayOrder.ID,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.ID)
+        private Long id;
+
+        @ApiModelProperty(
+                value = "클래스 일정 현재 상태 \n" +
+                        "ON_BOARD : 예정\n" +
+                        "ON_GOING : 진행 중\n" +
+                        "DONE : 완료",
+                position = PropertyDisplayOrder.STATE,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.STATE)
+        private Lecture.State state;
+
+        @ApiModelProperty(
+                value = "후기가 작성되었는지 여부",
+                position = PropertyDisplayOrder.IS_REVIEW_WRITTEN,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.IS_REVIEW_WRITTEN)
+        private boolean isReviewWritten;
+    }
+
+    private static class PropertyDisplayOrder {
+        private static final int ID = 0;
+        private static final int START_AT = 1;
+        private static final int END_AT = 2;
+        private static final int STATE = 3;
+        private static final int IS_REVIEW_WRITTEN = 4;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/LectureRegisterDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/LectureRegisterDto.java
@@ -1,0 +1,20 @@
+package kr.co.knowledgerally.api.lecture.dto;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "클래스 일정 등록 모델", description = "클래스 일정 등록용 모델")
+public class LectureRegisterDto {
+    @Valid
+    private List<LectureDto> schedules;
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/service/LectureRegisterService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/service/LectureRegisterService.java
@@ -1,0 +1,58 @@
+package kr.co.knowledgerally.api.lecture.service;
+
+import kr.co.knowledgerally.api.lecture.component.LectureMapper;
+import kr.co.knowledgerally.api.lecture.dto.LectureDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureRegisterDto;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.service.CoachService;
+import kr.co.knowledgerally.core.core.exception.BadRequestException;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import kr.co.knowledgerally.core.lecture.entity.LectureInformation;
+import kr.co.knowledgerally.core.lecture.repository.LectureInformationRepository;
+import kr.co.knowledgerally.core.lecture.repository.LectureRepository;
+import kr.co.knowledgerally.core.lecture.service.LectureInformationService;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LectureRegisterService {
+    private final LectureMapper lectureMapper;
+    private final LectureInformationService lectureInformationService;
+    private final LectureRepository lectureRepository;
+    private final CoachService coachService;
+
+    @Transactional
+    public List<LectureDto.ReadOnly> register(Long lectureInfoId, LectureRegisterDto registerDto, User loggedInUser) {
+        LectureInformation lectureInformation = lectureInformationService.findById(lectureInfoId);
+        checkIsValidUser(lectureInformation, loggedInUser);
+
+        List<Lecture> newLectures = registerDto.getSchedules().stream()
+                .map(lectureMapper::toEntity)
+                .peek(this::checkIsStartBeforeEnd)
+                .peek(lecture -> lecture.setLectureInformation(lectureInformation))
+                .collect(Collectors.toList());
+        return lectureRepository.saveAllAndFlush(newLectures).stream()
+                .map(lectureMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private void checkIsValidUser(LectureInformation lectureInformation, User loggedInUser) {
+        if (! Objects.equals(lectureInformation.getCoach().getUser().getId(), loggedInUser.getId())) {
+            throw new BadRequestException("해당 클래스-info의 주인이 아닙니다.");
+        }
+    }
+
+    private void checkIsStartBeforeEnd(Lecture lecture) {
+        if (lecture.getStartAt().isAfter(lecture.getEndAt())) {
+            throw new BadRequestException("시작일이 종료일보다 늦습니다.");
+        }
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/web/LectureController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/web/LectureController.java
@@ -1,0 +1,50 @@
+package kr.co.knowledgerally.api.lecture.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.core.annotation.CurrentUser;
+import kr.co.knowledgerally.api.core.dto.ApiPageRequest;
+import kr.co.knowledgerally.api.core.dto.ApiPageResult;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.lecture.component.LectureInformationMapper;
+import kr.co.knowledgerally.api.lecture.dto.LectureDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureInformationDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureRegisterDto;
+import kr.co.knowledgerally.api.lecture.service.LectureRegisterService;
+import kr.co.knowledgerally.core.lecture.entity.Category;
+import kr.co.knowledgerally.core.lecture.entity.LectureInformation;
+import kr.co.knowledgerally.core.lecture.service.CategoryService;
+import kr.co.knowledgerally.core.lecture.service.LectureInformationSearchService;
+import kr.co.knowledgerally.core.lecture.service.LectureInformationService;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@Api(value = "클래스 일정 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lecture-schedule")
+public class LectureController {
+    private final LectureRegisterService lectureRegisterService;
+
+    @ApiOperation(value = "클래스 일정 등록", notes = "클래스 일정을 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "성공"),
+    })
+    @PostMapping("/lectureinfo/{lectureInfoId}")
+    public ResponseEntity<ApiResult<List<LectureDto.ReadOnly>>> registerLecture (
+            @ApiParam(value = "클래스 정보 Id", required = true)
+            @PathVariable Long lectureInfoId,
+            @ApiParam(value = "등록할 클래스 일정 리스트", required = true)
+            @RequestBody @Valid LectureRegisterDto lectureRegisterDto,
+            @ApiIgnore @CurrentUser User loggedInUser) {
+
+        return ResponseEntity.ok(ApiResult.ok(
+                lectureRegisterService.register(lectureInfoId, lectureRegisterDto, loggedInUser)));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/DateTimeStringValidatorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/validation/DateTimeStringValidatorTest.java
@@ -1,0 +1,55 @@
+package kr.co.knowledgerally.api.core.validation;
+
+
+import kr.co.knowledgerally.api.core.validation.annotation.DateFormat;
+import kr.co.knowledgerally.api.core.validation.annotation.DateTimeFormat;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DateTimeStringValidatorTest extends AbstractValidatorTest {
+    @Test
+    public void 날짜시간문자열_검증_단순_테스트() {
+        DateTimeStringValidator validator = new DateTimeStringValidator();
+        assertTrue(validator.isValid("2020-10-14 22:35:42", null));
+        assertFalse(validator.isValid("20202-10-14 22:35:42", null));
+        assertFalse(validator.isValid("2020-13-14 22:35:42", null));
+        assertFalse(validator.isValid("2020-12-14 25:35:42", null));
+    }
+
+    @Test
+    public void 날짜시간문자열_검증_심화_테스트() {
+        SimpleDto simpleDto = new SimpleDto("2020-10-14 22:35:42");
+        Set<ConstraintViolation<SimpleDto>> violations = validator.validate(simpleDto);
+        assertTrue(violations.isEmpty());
+
+        simpleDto = new SimpleDto("20202-10-14 22:35:42");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+
+        simpleDto = new SimpleDto("2020-13-14 22:35:42");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+
+        simpleDto = new SimpleDto("2020-12-14 25:35:42");
+        violations = validator.validate(simpleDto);
+        assertFalse(violations.isEmpty());
+    }
+
+    private static class SimpleDto {
+        SimpleDto(String dateTimeString) {
+            this.dateTimeString = dateTimeString;
+        }
+
+        @DateTimeFormat
+        private final String dateTimeString;
+
+        public String getDateTimeString() {
+            return dateTimeString;
+        }
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/LectureMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/LectureMapperTest.java
@@ -1,0 +1,40 @@
+package kr.co.knowledgerally.api.lecture.component;
+
+import kr.co.knowledgerally.api.lecture.dto.LectureDto;
+import kr.co.knowledgerally.api.lecture.util.TestLectureDtoFactory;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import kr.co.knowledgerally.core.lecture.util.TestLectureEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class LectureMapperTest {
+    @Autowired
+    private LectureMapper lectureMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        Lecture lecture = new TestLectureEntityFactory().createEntity(1L);
+
+        LectureDto.ReadOnly lectureDto = lectureMapper.toDto(lecture);
+        assertEquals(1L, lectureDto.getId());
+        assertEquals("2022-06-15 10:30:50", lectureDto.getStartAt());
+        assertEquals("2022-06-15 11:30:50", lectureDto.getEndAt());
+        assertEquals(Lecture.State.ON_BOARD, lectureDto.getState());
+        assertFalse(lectureDto.isReviewWritten());
+    }
+
+    @Test
+    void DTO에서_엔티티변환_테스트() {
+        LectureDto lectureDto = new TestLectureDtoFactory().createDto(1L);
+
+        Lecture lecture = lectureMapper.toEntity(lectureDto);
+        assertEquals(LocalDateTime.of(2022, 6, 15, 10, 30, 50), lecture.getStartAt());
+        assertEquals(LocalDateTime.of(2022, 6, 15, 11, 30, 50), lecture.getEndAt());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestLectureDtoFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestLectureDtoFactory.java
@@ -1,0 +1,42 @@
+package kr.co.knowledgerally.api.lecture.util;
+
+import kr.co.knowledgerally.api.core.util.TestDtoFactory;
+import kr.co.knowledgerally.api.lecture.dto.LectureDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureImageDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureInformationDto;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+
+/**
+ * 테스트용 클래스 일정 Dto 생성 팩토리
+ */
+public class TestLectureDtoFactory implements TestDtoFactory<LectureDto> {
+
+    /**
+     * 테스트용 클래스 일정 Dto를 생성한다.
+     * @param id 생성될 Dto Id
+     * @return 생성된 클래스 일정 Dto
+     */
+    @Override
+    public LectureDto createDto(long id) {
+        return LectureDto.builder()
+                .startAt("2022-06-15 10:30:50")
+                .endAt("2022-06-15 11:30:50")
+                .build();
+    }
+
+    /**
+     * 테스트용 읽기전용 클래스 info Dto를 생성한다.
+     *
+     * @param id 생성될 Dto Id
+     * @return 생성된 읽기전용 클래스 info Dto
+     */
+    public LectureDto.ReadOnly createReadOnlyDto(long id) {
+        return LectureDto.ReadOnly.builder()
+                .id(id)
+                .startAt("2022-06-15 10:30:50")
+                .endAt("2022-06-15 11:30:50")
+                .state(Lecture.State.ON_BOARD)
+                .isReviewWritten(false)
+                .build();
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/LectureControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/LectureControllerTest.java
@@ -1,0 +1,79 @@
+package kr.co.knowledgerally.api.lecture.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LectureControllerTest extends AbstractControllerTest {
+    private static final String LECTURE_SCHEDULE_LECTUREINFO_URL = "/api/lecture-schedule/lectureinfo/";
+
+    @WithMockKnowllyUser
+    @Test
+    public void 클래스_일정_등록_테스트() throws Exception {
+        String json = "{" +
+                "   \"schedules\": [" +
+                "       {\"startAt\": \"2022-06-15 15:30:50\", \"endAt\": \"2022-06-15 16:30:50\"}," +
+                "       {\"startAt\": \"2022-06-15 18:30:50\", \"endAt\": \"2022-06-15 19:30:50\"}" +
+                "   ]" +
+                "}";
+
+        mockMvc.perform(
+                post(LECTURE_SCHEDULE_LECTUREINFO_URL + 1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json)
+        ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].startAt").value("2022-06-15 15:30:50"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].endAt").value("2022-06-15 16:30:50"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].state").value("ON_BOARD"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].reviewWritten").value(false))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].startAt").value("2022-06-15 18:30:50"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].endAt").value("2022-06-15 19:30:50"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].state").value("ON_BOARD"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].reviewWritten").value(false))
+                .andDo(print());
+    }
+
+    @WithMockKnowllyUser
+    @Test
+    public void 클래스_일정_등록_테스트_자기거_아니면_400() throws Exception {
+        String json = "{" +
+                "   \"schedules\": [" +
+                "       {\"startAt\": \"2022-06-15 15:30:50\", \"endAt\": \"2022-06-15 16:30:50\"}," +
+                "       {\"startAt\": \"2022-06-15 18:30:50\", \"endAt\": \"2022-06-15 19:30:50\"}" +
+                "   ]" +
+                "}";
+
+        mockMvc.perform(
+                        post(LECTURE_SCHEDULE_LECTUREINFO_URL + 2)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(json)
+                ).andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @WithMockKnowllyUser
+    @Test
+    public void 클래스_일정_등록_테스트_형식_잘못되면_400() throws Exception {
+        String json = "{" +
+                "   \"schedules\": [" +
+                "       {\"startAt\": \"2022-06-15 25:30:50\", \"endAt\": \"2022-06-15 26:30:50\"}," +
+                "       {\"startAt\": \"2022-06-15 18:30:50\", \"endAt\": \"2022-06-15 19:30:50\"}" +
+                "   ]" +
+                "}";
+
+        mockMvc.perform(
+                        post(LECTURE_SCHEDULE_LECTUREINFO_URL + 1)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(json)
+                ).andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ErrorMessage.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ErrorMessage.java
@@ -13,4 +13,7 @@ public class ErrorMessage {
     // Coach
     public static String NOT_EXIST_COACH = "존재하지 않는 코치입니다.";
     public static String USER_NOT_COACH = "사용자가 코치가 아닙니다.";
+
+    // LectureInfo
+    public static String NOT_EXIST_LECTURE_INFO = "존재하지 않는 클래스-info 입니다.";
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/LectureInformationService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/LectureInformationService.java
@@ -1,6 +1,8 @@
 package kr.co.knowledgerally.core.lecture.service;
 
 import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import kr.co.knowledgerally.core.core.message.ErrorMessage;
 import kr.co.knowledgerally.core.lecture.entity.Category;
 import kr.co.knowledgerally.core.lecture.entity.LectureInformation;
 import kr.co.knowledgerally.core.lecture.repository.LectureInformationRepository;
@@ -12,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
+
+import static kr.co.knowledgerally.core.core.message.ErrorMessage.NOT_EXIST_LECTURE_INFO;
 
 @Validated
 @Service
@@ -56,5 +60,17 @@ public class LectureInformationService {
     @Transactional
     public List<LectureInformation> searchAllByTopic(String topic) {
         return lectureInformationRepository.findAllByTopicContainingAndIsActiveOrderByIdDesc(topic, true);
+    }
+
+    /**
+     * 클래스 정보 ID로 클래스 정보 객체를 찾습니다.
+     * @param id 클래스 정보 ID
+     * @return 클래스-info 객체
+     * @throws ResourceNotFoundException 해당 id가 존재하지 않을 경우
+     */
+    @Transactional(readOnly = true)
+    public LectureInformation findById(Long id) throws ResourceNotFoundException {
+        return lectureInformationRepository.findById(id).orElseThrow(() ->
+                new ResourceNotFoundException(ErrorMessage.NOT_EXIST_LECTURE_INFO));
     }
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/LectureInformationServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/LectureInformationServiceTest.java
@@ -2,6 +2,7 @@ package kr.co.knowledgerally.core.lecture.service;
 
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
 import kr.co.knowledgerally.core.lecture.entity.Category;
 import kr.co.knowledgerally.core.lecture.entity.LectureInformation;
 import kr.co.knowledgerally.core.lecture.util.TestCategoryEntityFactory;
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -75,5 +77,28 @@ public class LectureInformationServiceTest {
         List<LectureInformation> lectureInformationList = lectureInformationService.searchAllByTopic("자바");
 
         assertEquals(lectureInformationList.get(0).getTopic(), "자바 개발");
+    }
+
+    @Test
+    void 클래스_info_ID로_검색() {
+        LectureInformation lectureInformation = lectureInformationService.findById(1L);
+
+        assertEquals(1L, lectureInformation.getId());
+        assertEquals(1L, lectureInformation.getCoach().getId());
+        assertEquals(4L, lectureInformation.getCategory().getId());
+        assertEquals("마케팅 수업", lectureInformation.getTopic());
+        assertEquals("효과적인 마케팅에 대해 배웁니다", lectureInformation.getIntroduce());
+        assertEquals(2, lectureInformation.getLectureImageSet().size());
+        assertEquals(1, lectureInformation.getPrice());
+        assertTrue(lectureInformation.isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 39, 40), lectureInformation.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 39, 54), lectureInformation.getUpdatedAt());
+    }
+
+    @Test
+    void 클래스_info_ID로_검색_없으면_throw() {
+        assertThrows(ResourceNotFoundException.class, () -> {
+            lectureInformationService.findById(9999L);
+        });
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- 클래스 일정을 등록할 수 있습니다.
- 로그인한 사용자의 클래스가 아니라면 400을 응답합니다.
- 시작일이 종료일을 넘어가면 400을 응답합니다.

## 주요 변경 사항
- 클래스 일정 등록 엔드포인트 추가
- DateTime Validator 추가
- 관련 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #58

@NaLDo627 @Park-Young-Hun
