### PR TITLE
[수정] health 체크 전용 컨트롤러 추가 및 deployment 설정 변경 (#104)

### DIFF
--- a/deployment/deployment-dev.yml
+++ b/deployment/deployment-dev.yml
@@ -18,17 +18,28 @@ spec:
           resources:
             requests:
               memory: "300Mi"
-              cpu: "500m"
+              cpu: "400m"
             limits:
               memory: "300Mi"
-              cpu: "500m"
+              cpu: "400m"
           ports:
             - containerPort: 8080
+          startupProbe:
+            httpGet:
+              path: /healthz/startup
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /healthz/liveness
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /api/test
+              path: /healthz/readiness
               port: 8080
-            initialDelaySeconds: 10
             periodSeconds: 5
             failureThreshold: 3
           env:

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/SecurityConfig.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     public static final String[] EXCLUDED_URLS = {
             "/test-cors",
+            "/healthz/*",
             "/api/test*",
             "/api/user/user-exists",
             "/api/user/signin",

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/web/HealthController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/web/HealthController.java
@@ -1,0 +1,42 @@
+package kr.co.knowledgerally.api.core.web;
+
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.core.core.exception.KnowllyException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+/**
+ * 테스트용 컨트롤러
+ */
+@ApiIgnore
+@RestController
+@RequestMapping("/healthz")
+public class HealthController {
+    @GetMapping("/liveness")
+    public ResponseEntity<ApiResult<TestObject>> liveness() {
+        return ResponseEntity.ok(ApiResult.ok(new TestObject("ok")));
+    }
+
+    @GetMapping("/readiness")
+    public ResponseEntity<ApiResult<TestObject>> readiness() {
+        return ResponseEntity.ok(ApiResult.ok(new TestObject("ok")));
+    }
+
+    @GetMapping("/startup")
+    public ResponseEntity<ApiResult<TestObject>> startup() {
+        return ResponseEntity.ok(ApiResult.ok(new TestObject("ok")));
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    public static class TestObject {
+        private String result;
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/web/HealthControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/web/HealthControllerTest.java
@@ -1,0 +1,41 @@
+package kr.co.knowledgerally.api.core.web;
+
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class HealthControllerTest extends AbstractControllerTest {
+    private static final String HEALTHZ_LIVENESS_TEST = "/healthz/liveness";
+    private static final String HEALTHZ_READINESS_TEST = "/healthz/readiness";
+    private static final String HEALTHZ_STARTUP_TEST = "/healthz/startup";
+
+    @Test
+    void HEALTHZ_liveness_TEST() throws Exception {
+        mockMvc.perform(
+                        get(HEALTHZ_LIVENESS_TEST)
+                ).andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    void HEALTHZ_readiness_TEST() throws Exception {
+        mockMvc.perform(
+                        get(HEALTHZ_READINESS_TEST)
+                ).andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    void HEALTHZ_startup_TEST() throws Exception {
+        mockMvc.perform(
+                        get(HEALTHZ_STARTUP_TEST)
+                ).andExpect(status().isOk())
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
## 작업 내용 설명
- health 체크 전용 컨트롤러 추가
- 해당 엔드포인트 로깅 제외

## 주요 변경 사항
- HealthController 추가
- deployment에 liveness, startup 추가로 적용
- 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #104 

@NaLDo627 @Park-Young-Hun
