### PR TITLE
[기능] 신청서 조회 기능 추가 (#65)(#66)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/FormMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/FormMapper.java
@@ -1,0 +1,23 @@
+package kr.co.knowledgerally.api.lecture.component;
+
+import kr.co.knowledgerally.api.lecture.dto.FormDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureDto;
+import kr.co.knowledgerally.api.user.component.UserMapper;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = { UserMapper.class, LectureMapper.class }
+)
+public interface FormMapper {
+    FormDto.ReadOnly toDto(Form form);
+    Form toEntity(FormDto lectureDto);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/FormDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/FormDto.java
@@ -1,0 +1,75 @@
+package kr.co.knowledgerally.api.lecture.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "신청서 모델", description = "신청서를 나타내는 모델")
+public class FormDto {
+    @ApiModelProperty(value = "신청 내용", position = PropertyDisplayOrder.CONTENT)
+    @JsonProperty(index = PropertyDisplayOrder.CONTENT)
+    private String content;
+
+    @SuperBuilder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value = "신청서 읽기 모델", description = "읽기 전용 신청서 모델")
+    public static class ReadOnly extends FormDto {
+        @ApiModelProperty(
+                value = "신청서 id",
+                position = PropertyDisplayOrder.ID,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.ID)
+        private Long id;
+
+        @ApiModelProperty(
+                value = "클래스 일정 읽기 모델",
+                position = PropertyDisplayOrder.LECTURE,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.LECTURE)
+        private LectureDto.ReadOnly lecture;
+
+        @ApiModelProperty(
+                value = "신청자 읽기 모델",
+                position = PropertyDisplayOrder.USER,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.USER)
+        private UserDto.ReadOnly user;
+
+        @ApiModelProperty(
+                value = "클래스 일정 현재 상태 \n" +
+                        "REQUEST : 요청된\n" +
+                        "ACCEPT : 수락된\n" +
+                        "REJECT : 거절된",
+                position = PropertyDisplayOrder.STATE,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.STATE)
+        private Form.State state;
+    }
+
+    private static class PropertyDisplayOrder {
+        private static final int ID = 0;
+        private static final int CONTENT = 1;
+        private static final int LECTURE = 2;
+        private static final int USER = 3;
+        private static final int STATE = 4;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/web/FormController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/web/FormController.java
@@ -1,0 +1,52 @@
+package kr.co.knowledgerally.api.lecture.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.core.annotation.CurrentUser;
+import kr.co.knowledgerally.api.core.dto.ApiPageRequest;
+import kr.co.knowledgerally.api.core.dto.ApiPageResult;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.lecture.component.FormMapper;
+import kr.co.knowledgerally.api.lecture.dto.FormDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureInformationDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureRegisterDto;
+import kr.co.knowledgerally.core.lecture.service.FormService;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Api(value = "신청서 관련 엔드포인트")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/form")
+public class FormController {
+    private final FormMapper formMapper;
+    private final FormService formService;
+
+    @ApiOperation(value = "내 신청서 조회", notes = "로그인한 사용자의 신청서 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "성공"),
+    })
+    @GetMapping("/me")
+    public ResponseEntity<ApiResult<List<FormDto.ReadOnly>>> getFormMe(@ApiIgnore @CurrentUser User loggedInUser) {
+        return ResponseEntity.ok(ApiResult.ok(
+                formService.findAllByUser(loggedInUser)
+                .stream().map(formMapper::toDto).collect(Collectors.toList())));
+    }
+
+    @ApiOperation(value = "신청서 조회", notes = "특정 신청서를 id로 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "성공"),
+    })
+    @GetMapping("/{formId}")
+    public ResponseEntity<ApiResult<FormDto.ReadOnly>> getFormById(
+            @ApiParam(value = "신청서 Id", required = true)
+            @PathVariable Long formId) {
+        return ResponseEntity.ok(ApiResult.ok(formMapper.toDto(formService.findById(formId))));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/FormMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/FormMapperTest.java
@@ -1,0 +1,40 @@
+package kr.co.knowledgerally.api.lecture.component;
+
+import kr.co.knowledgerally.api.lecture.dto.FormDto;
+import kr.co.knowledgerally.api.lecture.util.TestFormDtoFactory;
+import kr.co.knowledgerally.core.core.util.TestEntityFactory;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.util.TestFormEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class FormMapperTest {
+    @Autowired
+    FormMapper formMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        Form form = new TestFormEntityFactory().createEntity(1L, 1L, 4L);
+
+        FormDto.ReadOnly formDto = formMapper.toDto(form);
+
+        assertEquals(1L, formDto.getId());
+        assertEquals(1L, formDto.getLecture().getId());
+        assertEquals(4L, formDto.getUser().getId());
+        assertEquals("테스트1의 신청 내용", formDto.getContent());
+        assertEquals(Form.State.REQUEST, formDto.getState());
+    }
+
+    @Test
+    void DTO에서_엔티티변환_테스트() {
+        FormDto formDto = new TestFormDtoFactory().createDto(1L);
+
+        Form form = formMapper.toEntity(formDto);
+
+        assertEquals("테스트1의 신청 내용", form.getContent());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestFormDtoFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestFormDtoFactory.java
@@ -1,0 +1,47 @@
+package kr.co.knowledgerally.api.lecture.util;
+
+import kr.co.knowledgerally.api.core.util.TestDtoFactory;
+import kr.co.knowledgerally.api.lecture.dto.FormDto;
+import kr.co.knowledgerally.api.lecture.dto.LectureDto;
+import kr.co.knowledgerally.api.user.util.TestUserDtoFactory;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+
+/**
+ * 테스트용 신청서 Dto 생성 팩토리
+ */
+public class TestFormDtoFactory implements TestDtoFactory<FormDto> {
+
+    TestUserDtoFactory testUserDtoFactory = new TestUserDtoFactory();
+    TestLectureDtoFactory testLectureDtoFactory = new TestLectureDtoFactory();
+
+    /**
+     * 테스트용 신청서 Dto를 생성한다.
+     * @param id 생성될 Dto Id
+     * @return 생성된 신청서 Dto
+     */
+    @Override
+    public FormDto createDto(long id) {
+        return FormDto.builder()
+                .content(String.format("테스트%d의 신청 내용", id))
+                .build();
+    }
+
+    /**
+     * 테스트용 읽기전용 신청서 Dto를 생성한다.
+     *
+     * @param id 생성될 Dto Id
+     * @param lectureId 생성될 Dto 내부 lectureId
+     * @param userId 생성될 Dto 내부 userId
+     * @return 생성된 읽기전용 신청서 Dto
+     */
+    public FormDto.ReadOnly createReadOnlyDto(long id, long lectureId, long userId) {
+        return FormDto.ReadOnly.builder()
+                .id(id)
+                .content(String.format("테스트%d의 신청 내용", id))
+                .user(testUserDtoFactory.createReadOnlyDto(userId))
+                .lecture(testLectureDtoFactory.createReadOnlyDto(lectureId))
+                .state(Form.State.REQUEST)
+                .build();
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/FormControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/FormControllerTest.java
@@ -1,0 +1,44 @@
+package kr.co.knowledgerally.api.lecture.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class FormControllerTest extends AbstractControllerTest {
+    private static final String API_FORM = "/api/form/";
+    private static final String API_FORM_ME = "/api/form/me";
+
+    @WithMockKnowllyUser
+    @Test
+    void 내_신청서_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(API_FORM_ME)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].id").value(4))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].content").value("신청서를 받아주세요!"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lecture.id").value(4))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].user.id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].state").value("REQUEST"));
+    }
+
+    @WithMockKnowllyUser
+    @Test
+    void 신청서_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(API_FORM + 1)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content").value("신청서를 받아주세요!"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.lecture.id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.id").value(4))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.state").value("ACCEPT"));
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ErrorMessage.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/core/message/ErrorMessage.java
@@ -16,4 +16,7 @@ public class ErrorMessage {
 
     // LectureInfo
     public static String NOT_EXIST_LECTURE_INFO = "존재하지 않는 클래스-info 입니다.";
+
+    // Form
+    public static String NOT_EXIST_FORM = "존재하지 않는 신청서입니다.";
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/repository/FormRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/repository/FormRepository.java
@@ -1,7 +1,17 @@
 package kr.co.knowledgerally.core.lecture.repository;
 
 import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FormRepository extends JpaRepository<Form, Long> {
+    /**
+     * 사용자로 신청서 목록 조회
+     * @param user 사용자
+     * @param isActive 활성화 여부
+     * @return 신청서 목록
+     */
+    List<Form> findAllByUserAndIsActiveOrderByCreatedAtDesc(User user, boolean isActive);
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/FormService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/FormService.java
@@ -1,0 +1,45 @@
+package kr.co.knowledgerally.core.lecture.service;
+
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import kr.co.knowledgerally.core.core.message.ErrorMessage;
+import kr.co.knowledgerally.core.lecture.entity.Category;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.repository.CategoryRepository;
+import kr.co.knowledgerally.core.lecture.repository.FormRepository;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+import java.util.Optional;
+
+@Validated
+@Service
+@RequiredArgsConstructor
+public class FormService {
+    private final FormRepository formRepository;
+
+    /**
+     * id로 신청서를 조회합니다.
+     * @param id 신청서 id
+     * @return 신청서 객체
+     * @throws ResourceNotFoundException 해당하는 id가 존재하지 않을 때
+     */
+    @Transactional(readOnly = true)
+    public Form findById(long id) throws ResourceNotFoundException {
+        return formRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(ErrorMessage.NOT_EXIST_FORM));
+    }
+
+    /**
+     * 사용자로 신청서 목록을 조회합니다.
+     * @param user 사용자
+     * @return 신청서 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<Form> findAllByUser(User user) {
+        return formRepository.findAllByUserAndIsActiveOrderByCreatedAtDesc(user, true);
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/repository/FormRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/repository/FormRepositoryTest.java
@@ -1,0 +1,54 @@
+package kr.co.knowledgerally.core.lecture.repository;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KnowllyDataTest
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/coach.xml",
+        "classpath:dbunit/entity/category.xml",
+        "classpath:dbunit/entity/lecture_information.xml",
+        "classpath:dbunit/entity/lecture.xml",
+        "classpath:dbunit/entity/form.xml",
+})
+class FormRepositoryTest {
+    @Autowired
+    FormRepository formRepository;
+
+    @Test
+    void 사용자로_신청서_목록_찾기_테스트() {
+        User testUser = new TestUserEntityFactory().createEntity(3L);
+
+        List<Form> forms = formRepository.findAllByUserAndIsActiveOrderByCreatedAtDesc(testUser, true);
+
+        assertEquals(2, forms.size());
+        assertEquals(5L, forms.get(0).getId());
+        assertEquals(3L, forms.get(0).getLecture().getId());
+        assertEquals(3L, forms.get(0).getUser().getId());
+        assertEquals("신청 거절해주세요", forms.get(0).getContent());
+        assertEquals(Form.State.REJECT, forms.get(0).getState());
+        assertTrue(forms.get(0).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 51, 3), forms.get(0).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 51, 4), forms.get(0).getUpdatedAt());
+        assertEquals(2L, forms.get(1).getId());
+        assertEquals(2L, forms.get(1).getLecture().getId());
+        assertEquals(3L, forms.get(1).getUser().getId());
+        assertEquals("제 신청서를 받아주세요!", forms.get(1).getContent());
+        assertEquals(Form.State.ACCEPT, forms.get(1).getState());
+        assertTrue(forms.get(1).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 17), forms.get(1).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 17), forms.get(1).getUpdatedAt());
+    }
+}

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/FormServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/FormServiceTest.java
@@ -1,0 +1,77 @@
+package kr.co.knowledgerally.core.lecture.service;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@KnowllyDataTest
+@DatabaseSetup({
+        "classpath:dbunit/entity/user.xml",
+        "classpath:dbunit/entity/coach.xml",
+        "classpath:dbunit/entity/category.xml",
+        "classpath:dbunit/entity/lecture_information.xml",
+        "classpath:dbunit/entity/lecture.xml",
+        "classpath:dbunit/entity/form.xml",
+})
+@Import(FormService.class)
+class FormServiceTest {
+    @Autowired
+    FormService formService;
+
+    @Test
+    void ID로_신청서_찾기_테스트() {
+        Form form = formService.findById(1L);
+
+        assertEquals(1L, form.getId());
+        assertEquals(1L, form.getLecture().getId());
+        assertEquals(4L, form.getUser().getId());
+        assertEquals("신청서를 받아주세요!", form.getContent());
+        assertEquals(Form.State.ACCEPT, form.getState());
+        assertTrue(form.isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 17), form.getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 17), form.getUpdatedAt());
+    }
+
+    @Test
+    void ID로_신청서_찾기_테스트_없으면_throw() {
+        assertThrows(ResourceNotFoundException.class, () -> {
+            formService.findById(9999L);
+        });
+    }
+
+    @Test
+    void 사용자로_신청서_찾기_테스트() {
+        User testUser = new TestUserEntityFactory().createEntity(3L);
+
+        List<Form> forms = formService.findAllByUser(testUser);
+
+        assertEquals(2, forms.size());
+        assertEquals(5L, forms.get(0).getId());
+        assertEquals(3L, forms.get(0).getLecture().getId());
+        assertEquals(3L, forms.get(0).getUser().getId());
+        assertEquals("신청 거절해주세요", forms.get(0).getContent());
+        assertEquals(Form.State.REJECT, forms.get(0).getState());
+        assertTrue(forms.get(0).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 51, 3), forms.get(0).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 51, 4), forms.get(0).getUpdatedAt());
+        assertEquals(2L, forms.get(1).getId());
+        assertEquals(2L, forms.get(1).getLecture().getId());
+        assertEquals(3L, forms.get(1).getUser().getId());
+        assertEquals("제 신청서를 받아주세요!", forms.get(1).getContent());
+        assertEquals(Form.State.ACCEPT, forms.get(1).getState());
+        assertTrue(forms.get(1).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 17), forms.get(1).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 17), forms.get(1).getUpdatedAt());
+    }
+}


### PR DESCRIPTION
## 작업 내용 설명
- 로그인한 사용자의 매칭 신청서 목록 조회 추가
- 특정 매칭 신청서 조회 추가

## 주요 변경 사항
- 로그인한 사용자의 매칭 신청서 목록 조회 추가
- 특정 매칭 신청서 조회 추가
- 관련 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #65 
- resolved #66

@NaLDo627 @Park-Young-Hun
