### PR TITLE
[기능] 수강 클래스 조회 기능 추가 (#25)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/UserLectureMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/UserLectureMapper.java
@@ -1,0 +1,20 @@
+package kr.co.knowledgerally.api.lecture.component;
+
+import kr.co.knowledgerally.api.lecture.dto.CoachLectureDto;
+import kr.co.knowledgerally.api.lecture.dto.UserLectureDto;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = {LectureInformationMapper.class, FormMapper.class}
+)
+public interface UserLectureMapper {
+    @Mapping(target = "form", source = "form")
+    @Mapping(target = "lectureInformation", source = "form.lecture.lectureInformation")
+    UserLectureDto toDto(Form form);
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/UserLectureDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/UserLectureDto.java
@@ -1,0 +1,41 @@
+package kr.co.knowledgerally.api.lecture.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "수강 클래스 조회 모델", description = "수강 클래스를 나타내는 모델")
+public class UserLectureDto {
+    @ApiModelProperty(
+            value = "신청서 읽기 모델",
+            position = PropertyDisplayOrder.FORM,
+            accessMode = ApiModelProperty.AccessMode.READ_ONLY
+    )
+    @JsonProperty(index = PropertyDisplayOrder.FORM)
+    private FormDto.ReadOnly form;
+
+    @ApiModelProperty(
+            value = "클래스-info 읽기 모델",
+            position = PropertyDisplayOrder.LECTURE_INFORMATION,
+            accessMode = ApiModelProperty.AccessMode.READ_ONLY
+    )
+    @JsonProperty(index = PropertyDisplayOrder.LECTURE_INFORMATION)
+    private LectureInformationDto.ReadOnly lectureInformation;
+
+    private static class PropertyDisplayOrder {
+        private static final int FORM = 0;
+        private static final int LECTURE_INFORMATION = 1;
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/service/UserLectureService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/service/UserLectureService.java
@@ -1,0 +1,52 @@
+package kr.co.knowledgerally.api.lecture.service;
+
+import kr.co.knowledgerally.api.lecture.component.CoachLectureMapper;
+import kr.co.knowledgerally.api.lecture.component.UserLectureMapper;
+import kr.co.knowledgerally.api.lecture.dto.CoachLectureDto;
+import kr.co.knowledgerally.api.lecture.dto.FormDto;
+import kr.co.knowledgerally.api.lecture.dto.UserLectureDto;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.service.CoachService;
+import kr.co.knowledgerally.core.core.exception.BadRequestException;
+import kr.co.knowledgerally.core.core.message.ErrorMessage;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import kr.co.knowledgerally.core.lecture.repository.LectureRepository;
+import kr.co.knowledgerally.core.lecture.service.FormService;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserLectureService {
+    private final FormService formService;
+    private final UserLectureMapper userLectureMapper;
+
+    /**
+     * 수강 클래스를 조회합니다.
+     * @param loggedInUser 로그인된 사용자
+     * @param state 클래스 상태, null시 전체 조회
+     * @return 운영 클래스 dto 목록
+     */
+    @Transactional(readOnly = true)
+    public List<UserLectureDto> getUserLecture(User loggedInUser, @Nullable Lecture.State state) {
+        return getForms(loggedInUser, state).stream()
+                .map(userLectureMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private List<Form> getForms(User user, Lecture.State state) {
+        if (state != null) {
+            return formService.findAllByUserAndLectureState(user, state);
+        }
+        return formService.findAllByUser(user);
+    }
+}

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/web/UserLectureController.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/web/UserLectureController.java
@@ -1,0 +1,43 @@
+package kr.co.knowledgerally.api.lecture.web;
+
+import io.swagger.annotations.*;
+import kr.co.knowledgerally.api.core.annotation.CurrentUser;
+import kr.co.knowledgerally.api.core.dto.ApiResult;
+import kr.co.knowledgerally.api.lecture.dto.CoachLectureDto;
+import kr.co.knowledgerally.api.lecture.dto.UserLectureDto;
+import kr.co.knowledgerally.api.lecture.service.CoachLectureService;
+import kr.co.knowledgerally.api.lecture.service.UserLectureService;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import kr.co.knowledgerally.core.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+import java.util.List;
+
+@Api(value = "수강 클래스 관련 엔드포인트", tags = "수강 클래스")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/lecture")
+public class UserLectureController {
+    private final UserLectureService userLectureService;
+
+    @ApiOperation(value = "수강 클래스 조회", notes = "로그인한 사용자의 수강 클래스를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "성공"),
+    })
+    @GetMapping("/me")
+    public ResponseEntity<ApiResult<List<UserLectureDto>>> getCoachLectureMe(@ApiIgnore @CurrentUser User loggedInUser,
+                                                                             @ApiParam(value = "클래스 진행 상태, 없을 시 전체 조회\n" +
+                                                                                      "ON_BOARD : 예정\n" +
+                                                                                      "ON_GOING : 진행 중\n" +
+                                                                                      "DONE : 완료", required = false)
+                                                                              @RequestParam(value = "state", required = false)
+                                                                              Lecture.State state) {
+        return ResponseEntity.ok(ApiResult.ok(userLectureService.getUserLecture(loggedInUser, state)));
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/annotation/WithMockKnowllyUser.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/annotation/WithMockKnowllyUser.java
@@ -10,4 +10,5 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithMockKnowllyUserSecurityContextFactory.class)
 public @interface WithMockKnowllyUser {
+    long userId() default 1;
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/config/WithMockKnowllyUserSecurityContextFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/config/WithMockKnowllyUserSecurityContextFactory.java
@@ -16,7 +16,7 @@ public class WithMockKnowllyUserSecurityContextFactory implements WithSecurityCo
         TestUserEntityFactory userEntityFactory = new TestUserEntityFactory();
 
         UserDetailsImpl principal =
-                new UserDetailsImpl(userEntityFactory.createEntity(1L));
+                new UserDetailsImpl(userEntityFactory.createEntity(customUser.userId()));
         Authentication auth =
                 new UsernamePasswordAuthenticationToken(principal, "password", principal.getAuthorities());
         context.setAuthentication(auth);

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/UserLectureMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/UserLectureMapperTest.java
@@ -1,0 +1,38 @@
+package kr.co.knowledgerally.api.lecture.component;
+
+import kr.co.knowledgerally.api.lecture.dto.LectureInformationDto;
+import kr.co.knowledgerally.api.lecture.dto.UserLectureDto;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.util.TestFormEntityFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserLectureMapperTest {
+    @Autowired
+    UserLectureMapper userLectureMapper;
+
+    @Test
+    void 엔티티에서_DTO변환_테스트() {
+        Form form = new TestFormEntityFactory().createEntity(1L);
+
+        UserLectureDto userLectureDto = userLectureMapper.toDto(form);
+
+        assertEquals(1L, userLectureDto.getForm().getId());
+        assertEquals(1L, userLectureDto.getForm().getLecture().getId());
+        assertEquals(1L, userLectureDto.getForm().getUser().getId());
+        assertEquals("테스트1의 신청 내용", userLectureDto.getForm().getContent());
+        assertEquals(Form.State.REQUEST, userLectureDto.getForm().getState());
+
+        LectureInformationDto.ReadOnly lectureInformationDto = userLectureDto.getLectureInformation();
+        assertEquals("테스트1 제목", lectureInformationDto.getTopic());
+        assertEquals("안녕하세요. 테스트1 입니다.", lectureInformationDto.getIntroduce());
+        assertEquals(1, lectureInformationDto.getPrice());
+        assertEquals(1, lectureInformationDto.getCoach().getId());
+        assertEquals("테스트 카테고리1", lectureInformationDto.getCategory().getCategoryName());
+        assertEquals(2, lectureInformationDto.getLectureImageSet().size());
+    }
+}

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CoachLectureControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CoachLectureControllerTest.java
@@ -46,4 +46,13 @@ class CoachLectureControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lectureInformation.id").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].forms[0].id").value(6));
     }
+
+    @WithMockKnowllyUser(userId = 2)
+    @Test
+    void 운영_클래스_코치_아니면_400() throws Exception {
+        mockMvc.perform(
+                        get(API_COACH_LECTURE_ME)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isBadRequest());
+    }
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/LectureInformationControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/LectureInformationControllerTest.java
@@ -11,7 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class LectureInformationControllerTest extends AbstractControllerTest {
     private static final String LECTUREINFORMATION_URL = "/api/lectureinfo";
-    private  static final String LECTUREINFORMATION_SEARCH_URL = "/api/lectureinfo/search";
+    private static final String LECTUREINFORMATION_SEARCH_URL = "/api/lectureinfo/search";
 
     @WithMockKnowllyUser
     @Test

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/UserLectureControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/UserLectureControllerTest.java
@@ -1,0 +1,41 @@
+package kr.co.knowledgerally.api.lecture.web;
+
+import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
+import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserLectureControllerTest extends AbstractControllerTest {
+    private static final String API_USER_LECTURE_ME = "/api/user/lecture/me";
+
+    @WithMockKnowllyUser
+    @Test
+    void 수강_클래스_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(API_USER_LECTURE_ME)
+                                .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].form.id").value(4))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].form.lecture.id").value(4))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lectureInformation.id").value(2));
+    }
+
+    @WithMockKnowllyUser
+    @Test
+    void 수강_클래스_매칭중_조회_테스트() throws Exception {
+        mockMvc.perform(
+                        get(API_USER_LECTURE_ME)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .param("state", "ON_BOARD")
+                ).andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].form.id").value(4))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].form.lecture.id").value(4))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].form.lecture.state").value("ON_BOARD"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lectureInformation.id").value(2));
+    }
+}

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/repository/FormRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/repository/FormRepository.java
@@ -1,6 +1,7 @@
 package kr.co.knowledgerally.core.lecture.repository;
 
 import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
 import kr.co.knowledgerally.core.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -23,4 +24,13 @@ public interface FormRepository extends JpaRepository<Form, Long> {
      * @return 신청서 목록
      */
     List<Form> findAllByUserAndStateAndIsActiveOrderByCreatedAtDesc(User user, Form.State state, boolean isActive);
+
+    /**
+     * 사용자로 신청서 목록 조회
+     * @param user 사용자
+     * @param state 클래스 일정 상태
+     * @param isActive 활성화 여부
+     * @return 신청서 목록
+     */
+    List<Form> findAllByUserAndLecture_StateAndIsActiveOrderByCreatedAtDesc(User user, Lecture.State state, boolean isActive);
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/FormService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/FormService.java
@@ -3,6 +3,7 @@ package kr.co.knowledgerally.core.lecture.service;
 import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
 import kr.co.knowledgerally.core.core.message.ErrorMessage;
 import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
 import kr.co.knowledgerally.core.lecture.repository.FormRepository;
 import kr.co.knowledgerally.core.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -49,5 +50,16 @@ public class FormService {
     @Transactional(readOnly = true)
     public List<Form> findAllByUserAndState(User user, Form.State state) {
         return formRepository.findAllByUserAndStateAndIsActiveOrderByCreatedAtDesc(user, state,true);
+    }
+
+    /**
+     * 사용자로 신청서 목록을 조회합니다.
+     * @param user 사용자
+     * @param state 클래스 일정 상태
+     * @return 신청서 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<Form> findAllByUserAndLectureState(User user, Lecture.State state) {
+        return formRepository.findAllByUserAndLecture_StateAndIsActiveOrderByCreatedAtDesc(user, state,true);
     }
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/repository/FormRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/repository/FormRepositoryTest.java
@@ -3,6 +3,7 @@ package kr.co.knowledgerally.core.lecture.repository;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
 import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
 import kr.co.knowledgerally.core.user.entity.User;
 import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,23 @@ class FormRepositoryTest {
         User testUser = new TestUserEntityFactory().createEntity(3L);
 
         List<Form> forms = formRepository.findAllByUserAndStateAndIsActiveOrderByCreatedAtDesc(testUser, Form.State.ACCEPT, true);
+
+        assertEquals(1, forms.size());
+        assertEquals(2L, forms.get(0).getId());
+        assertEquals(2L, forms.get(0).getLecture().getId());
+        assertEquals(3L, forms.get(0).getUser().getId());
+        assertEquals("제 신청서를 받아주세요!", forms.get(0).getContent());
+        assertEquals(Form.State.ACCEPT, forms.get(0).getState());
+        assertTrue(forms.get(0).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 18), forms.get(0).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 18), forms.get(0).getUpdatedAt());
+    }
+
+    @Test
+    void 사용자로_신청서_목록_찾기_클래스_상태_조회_테스트() {
+        User testUser = new TestUserEntityFactory().createEntity(3L);
+
+        List<Form> forms = formRepository.findAllByUserAndLecture_StateAndIsActiveOrderByCreatedAtDesc(testUser, Lecture.State.ON_GOING, true);
 
         assertEquals(1, forms.size());
         assertEquals(2L, forms.get(0).getId());

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/FormServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/FormServiceTest.java
@@ -4,6 +4,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
 import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
 import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
 import kr.co.knowledgerally.core.user.entity.User;
 import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
 import org.junit.jupiter.api.Test;
@@ -80,6 +81,23 @@ class FormServiceTest {
         User testUser = new TestUserEntityFactory().createEntity(3L);
 
         List<Form> forms = formService.findAllByUserAndState(testUser, Form.State.ACCEPT);
+
+        assertEquals(1, forms.size());
+        assertEquals(2L, forms.get(0).getId());
+        assertEquals(2L, forms.get(0).getLecture().getId());
+        assertEquals(3L, forms.get(0).getUser().getId());
+        assertEquals("제 신청서를 받아주세요!", forms.get(0).getContent());
+        assertEquals(Form.State.ACCEPT, forms.get(0).getState());
+        assertTrue(forms.get(0).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 18), forms.get(0).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 18), forms.get(0).getUpdatedAt());
+    }
+
+    @Test
+    void 사용자로_신청서_목록_찾기_클래스_상태_조회_테스트() {
+        User testUser = new TestUserEntityFactory().createEntity(3L);
+
+        List<Form> forms = formService.findAllByUserAndLectureState(testUser, Lecture.State.ON_GOING);
 
         assertEquals(1, forms.size());
         assertEquals(2L, forms.get(0).getId());


### PR DESCRIPTION
## 작업 내용 설명
- 수강 클래스를 조회할 수 있다.

## 주요 변경 사항
- 수강 클래스 조회 엔드포인트 추가
- 테스트 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #25

@NaLDo627 @Park-Young-Hun
