### PR TITLE
[수정] 운영 클래스 조회 응답 포맷 수정 (#119)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/CoachLectureMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/CoachLectureMapper.java
@@ -18,5 +18,9 @@ public interface CoachLectureMapper {
     @Mapping(target = "lecture", source = "lecture")
     @Mapping(target = "lectureInformation", source = "lecture.lectureInformation")
     @Mapping(target = "forms", source = "lecture.forms")
+    @Mapping(target = "isMatched", expression = "java(lecture.getState() != " +
+            "kr.co.knowledgerally.core.lecture.entity.Lecture.State.ON_BOARD)")
+    @Mapping(target = "matchedUser", expression = "java(lecture.getState() != " + // forms에는 매칭된 사람 신청서만 있다는 전제조건을 깔고 감
+            "kr.co.knowledgerally.core.lecture.entity.Lecture.State.ON_BOARD ? lecture.getForms().get(0).getUser() : null)")
     CoachLectureDto toDto(Lecture lecture);
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/CoachLectureDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/CoachLectureDto.java
@@ -3,6 +3,7 @@ package kr.co.knowledgerally.api.lecture.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.core.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -42,9 +43,27 @@ public class CoachLectureDto {
     @JsonProperty(index = PropertyDisplayOrder.FORMS)
     private List<FormDto.ReadOnly> forms;
 
+    @ApiModelProperty(
+            value = "매칭되었는지에 대한 여부",
+            position = PropertyDisplayOrder.IS_MATCHED,
+            accessMode = ApiModelProperty.AccessMode.READ_ONLY
+    )
+    @JsonProperty(index = PropertyDisplayOrder.IS_MATCHED)
+    private boolean isMatched;
+
+    @ApiModelProperty(
+            value = "매칭된 유저. 아직 매칭 중인 상태라면 null",
+            position = PropertyDisplayOrder.MATCHED_USER,
+            accessMode = ApiModelProperty.AccessMode.READ_ONLY
+    )
+    @JsonProperty(index = PropertyDisplayOrder.MATCHED_USER)
+    private User matchedUser;
+
     private static class PropertyDisplayOrder {
         private static final int LECTURE = 0;
         private static final int LECTURE_INFORMATION = 1;
         private static final int FORMS = 2;
+        private static final int IS_MATCHED = 3;
+        private static final int MATCHED_USER = 4;
     }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/service/CoachFormService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/service/CoachFormService.java
@@ -12,6 +12,7 @@ import kr.co.knowledgerally.core.lecture.entity.Form;
 import kr.co.knowledgerally.core.lecture.entity.Lecture;
 import kr.co.knowledgerally.core.lecture.repository.LectureRepository;
 import kr.co.knowledgerally.core.lecture.service.FormService;
+import kr.co.knowledgerally.core.lecture.service.LectureService;
 import kr.co.knowledgerally.core.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,11 +55,22 @@ public class CoachFormService {
             throw new BadRequestException(ErrorMessage.FORM_IS_NOT_BELONG_TO_THIS_COACH);
         }
 
+        if (state == Form.State.ACCEPT) {
+            // 해당 클래스의 다른 신청서는 모두 reject 처리해버린다.
+            makeAllFormsToRejectState(coach);
+        }
+
         form.setState(state);
         return formMapper.toDto(formService.saveForm(form));
     }
 
     private boolean isNotFormLectureBelongToCoach(Form form, Coach coach) {
         return ! Objects.equals(form.getLecture().getLectureInformation().getCoach().getId(), coach.getId());
+    }
+
+    private void makeAllFormsToRejectState(Coach coach) {
+        for (Form form : formService.findAllByLectureCoach(coach)) {
+            form.setState(Form.State.REJECT);
+        }
     }
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/CoachLectureMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/CoachLectureMapperTest.java
@@ -22,7 +22,7 @@ class CoachLectureMapperTest {
     TestFormEntityFactory testFormEntityFactory = new TestFormEntityFactory();
 
     @Test
-    void 엔티티에서_DTO변환_테스트() {
+    void 엔티티에서_DTO변환_매칭중_테스트() {
         Lecture lecture = new TestLectureEntityFactory().createEntity(1L);
         lecture.setForms(List.of(testFormEntityFactory.createEntity(1L),
                 testFormEntityFactory.createEntity(2L)));
@@ -34,6 +34,8 @@ class CoachLectureMapperTest {
         assertEquals("2022-06-15T11:30:50", coachLectureDto.getLecture().getEndAt());
         assertEquals(Lecture.State.ON_BOARD, coachLectureDto.getLecture().getState());
         assertFalse(coachLectureDto.getLecture().isReviewWritten());
+        assertFalse(coachLectureDto.isMatched());
+        assertNull(coachLectureDto.getMatchedUser());
 
         assertEquals("테스트1 제목", coachLectureDto.getLectureInformation().getTopic());
         assertEquals("안녕하세요. 테스트1 입니다.", coachLectureDto.getLectureInformation().getIntroduce());
@@ -53,5 +55,39 @@ class CoachLectureMapperTest {
         assertEquals(1L, coachLectureDto.getForms().get(1).getUser().getId());
         assertEquals("테스트2의 신청 내용", coachLectureDto.getForms().get(1).getContent());
         assertEquals(Form.State.REQUEST, coachLectureDto.getForms().get(1).getState());
+    }
+
+    @Test
+    void 엔티티에서_DTO변환_매칭완료_테스트() {
+        Lecture lecture = new TestLectureEntityFactory().createEntity(1L);
+        lecture.setState(Lecture.State.ON_GOING);
+        Form form = testFormEntityFactory.createEntity(1L);
+        form.setState(Form.State.ACCEPT);
+        lecture.setForms(List.of(form));
+
+        CoachLectureDto coachLectureDto = coachLectureMapper.toDto(lecture);
+
+        assertEquals(1L, coachLectureDto.getLecture().getId());
+        assertEquals("2022-06-15T10:30:50", coachLectureDto.getLecture().getStartAt());
+        assertEquals("2022-06-15T11:30:50", coachLectureDto.getLecture().getEndAt());
+        assertEquals(Lecture.State.ON_GOING, coachLectureDto.getLecture().getState());
+        assertFalse(coachLectureDto.getLecture().isReviewWritten());
+        assertTrue(coachLectureDto.isMatched());
+        assertNotNull(coachLectureDto.getMatchedUser());
+        assertEquals(1L, coachLectureDto.getMatchedUser().getId());
+
+        assertEquals("테스트1 제목", coachLectureDto.getLectureInformation().getTopic());
+        assertEquals("안녕하세요. 테스트1 입니다.", coachLectureDto.getLectureInformation().getIntroduce());
+        assertEquals(1, coachLectureDto.getLectureInformation().getPrice());
+        assertEquals(1, coachLectureDto.getLectureInformation().getCoach().getId());
+        assertEquals("테스트 카테고리1", coachLectureDto.getLectureInformation().getCategory().getCategoryName());
+        assertEquals(2, coachLectureDto.getLectureInformation().getLectureImageSet().size());
+
+        assertEquals(1, coachLectureDto.getForms().size());
+        assertEquals(1L, coachLectureDto.getForms().get(0).getId());
+        assertEquals(1L, coachLectureDto.getForms().get(0).getLecture().getId());
+        assertEquals(1L, coachLectureDto.getForms().get(0).getUser().getId());
+        assertEquals("테스트1의 신청 내용", coachLectureDto.getForms().get(0).getContent());
+        assertEquals(Form.State.ACCEPT, coachLectureDto.getForms().get(0).getState());
     }
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CoachFormControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CoachFormControllerTest.java
@@ -2,7 +2,11 @@ package kr.co.knowledgerally.api.lecture.web;
 
 import kr.co.knowledgerally.api.annotation.WithMockKnowllyUser;
 import kr.co.knowledgerally.api.web.AbstractControllerTest;
+import kr.co.knowledgerally.core.lecture.entity.Form;
+import kr.co.knowledgerally.core.lecture.repository.FormRepository;
+import kr.co.knowledgerally.core.lecture.service.FormService;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -14,12 +18,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class CoachFormControllerTest extends AbstractControllerTest {
     private static final String COACH_FORM_FORMAT_STATE = "/api/coach/form/%d/state";
 
+    @Autowired
+    FormService formService;
+
     @WithMockKnowllyUser(userId = 3)
     @Test
     void 신청서_상태_변경_테스트() throws Exception {
         final String json = "{" +
                 "   \"state\": \"ACCEPT\"" +
                 "}";
+
+        assertEquals(Form.State.REQUEST, formService.findById(4L).getState());
+        assertEquals(Form.State.REQUEST, formService.findById(7L).getState());
 
         mockMvc.perform(
                         patch(String.format(COACH_FORM_FORMAT_STATE, 4))
@@ -30,6 +40,10 @@ class CoachFormControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.lecture.id").value(4))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.id").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.state").value("ACCEPT"));
+
+        // 다른 신청서는 reject 처리되어야 함
+        assertEquals(Form.State.ACCEPT, formService.findById(4L).getState());
+        assertEquals(Form.State.REJECT, formService.findById(7L).getState());
     }
 
     @WithMockKnowllyUser(userId = 3)

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CoachLectureControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CoachLectureControllerTest.java
@@ -21,16 +21,25 @@ class CoachLectureControllerTest extends AbstractControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                 ).andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lecture.id").value(3))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lecture.state").value("ON_BOARD"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lectureInformation.id").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].forms[0].id").value(6))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].matched").value(false))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].matchedUser").isEmpty())
 
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].lecture.id").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].lecture.state").value("ON_GOING"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].lectureInformation.id").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].forms[0].id").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].matched").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].matchedUser").isNotEmpty())
 
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[2].lecture.id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[2].lecture.state").value("DONE"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[2].lectureInformation.id").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[2].forms[0].id").value(1));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[2].forms[0].id").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[2].matched").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[2].matchedUser").isNotEmpty());
     }
 
     @WithMockKnowllyUser
@@ -44,7 +53,9 @@ class CoachLectureControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lecture.id").value(3))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lecture.state").value("ON_BOARD"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lectureInformation.id").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].forms[0].id").value(6));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].forms[0].id").value(6))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].matched").value(false))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].matchedUser").isEmpty());
     }
 
     @WithMockKnowllyUser(userId = 2)

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/repository/FormRepository.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/repository/FormRepository.java
@@ -1,5 +1,6 @@
 package kr.co.knowledgerally.core.lecture.repository;
 
+import kr.co.knowledgerally.core.coach.entity.Coach;
 import kr.co.knowledgerally.core.lecture.entity.Form;
 import kr.co.knowledgerally.core.lecture.entity.Lecture;
 import kr.co.knowledgerally.core.user.entity.User;
@@ -33,4 +34,12 @@ public interface FormRepository extends JpaRepository<Form, Long> {
      * @return 신청서 목록
      */
     List<Form> findAllByUserAndLecture_StateAndIsActiveOrderByCreatedAtDesc(User user, Lecture.State state, boolean isActive);
+
+    /**
+     * 코치 앞으로 온 신청서 목록 조회
+     * @param coach 코치
+     * @param isActive 활성화 여부
+     * @return 신청서 목록
+     */
+    List<Form> findAllByLecture_LectureInformation_CoachAndIsActiveOrderByCreatedAtDesc(Coach coach, boolean isActive);
 }

--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/FormService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/FormService.java
@@ -1,5 +1,6 @@
 package kr.co.knowledgerally.core.lecture.service;
 
+import kr.co.knowledgerally.core.coach.entity.Coach;
 import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
 import kr.co.knowledgerally.core.core.message.ErrorMessage;
 import kr.co.knowledgerally.core.lecture.entity.Form;
@@ -72,5 +73,15 @@ public class FormService {
     @Transactional(readOnly = true)
     public List<Form> findAllByUserAndLectureState(User user, Lecture.State state) {
         return formRepository.findAllByUserAndLecture_StateAndIsActiveOrderByCreatedAtDesc(user, state,true);
+    }
+
+    /**
+     * 코치로 신청서 목록을 조회합니다.
+     * @param coach 코치
+     * @return 신청서 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<Form> findAllByLectureCoach(Coach coach) {
+        return formRepository.findAllByLecture_LectureInformation_CoachAndIsActiveOrderByCreatedAtDesc(coach, true);
     }
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/repository/FormRepositoryTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/repository/FormRepositoryTest.java
@@ -2,6 +2,8 @@ package kr.co.knowledgerally.core.lecture.repository;
 
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
 import kr.co.knowledgerally.core.lecture.entity.Form;
 import kr.co.knowledgerally.core.lecture.entity.Lecture;
 import kr.co.knowledgerally.core.user.entity.User;
@@ -85,5 +87,32 @@ class FormRepositoryTest {
         assertTrue(forms.get(0).isActive());
         assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 18), forms.get(0).getCreatedAt());
         assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 18), forms.get(0).getUpdatedAt());
+    }
+
+    @Test
+    void 클래스_코치로_신청서_목록_찾기_테스트() {
+        Coach coach = new TestCoachEntityFactory().createEntity(2L);
+
+        List<Form> forms = formRepository.findAllByLecture_LectureInformation_CoachAndIsActiveOrderByCreatedAtDesc(coach, true);
+
+        assertEquals(2, forms.size());
+
+        assertEquals(7L, forms.get(0).getId());
+        assertEquals(4L, forms.get(0).getLecture().getId());
+        assertEquals(2L, forms.get(0).getUser().getId());
+        assertEquals("신청서를 받아주세요!", forms.get(0).getContent());
+        assertEquals(Form.State.REQUEST, forms.get(0).getState());
+        assertTrue(forms.get(0).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 51, 5), forms.get(0).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 51, 6), forms.get(0).getUpdatedAt());
+
+        assertEquals(4L, forms.get(1).getId());
+        assertEquals(4L, forms.get(1).getLecture().getId());
+        assertEquals(1L, forms.get(1).getUser().getId());
+        assertEquals("신청서를 받아주세요!", forms.get(1).getContent());
+        assertEquals(Form.State.REQUEST, forms.get(1).getState());
+        assertTrue(forms.get(1).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 20), forms.get(1).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 20), forms.get(1).getUpdatedAt());
     }
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/repository/crud/FormRepositoryCrudTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/repository/crud/FormRepositoryCrudTest.java
@@ -51,7 +51,7 @@ class FormRepositoryCrudTest extends AbstractRepositoryCrudTest {
     @ExpectedDatabase(value = "classpath:dbunit/expected/crud/form_insert_test.xml",
             assertionMode = DatabaseAssertionMode.NON_STRICT)
     protected void insertTest() {
-        Form form = testFormEntityFactory.createEntity(7L, 4, 2);
+        Form form = testFormEntityFactory.createEntity(8L, 4, 3);
         formRepository.saveAndFlush(form);
     }
 

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/FormServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/FormServiceTest.java
@@ -4,6 +4,8 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.ExpectedDatabase;
 import com.github.springtestdbunit.assertion.DatabaseAssertionMode;
 import kr.co.knowledgerally.core.annotation.KnowllyDataTest;
+import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
 import kr.co.knowledgerally.core.core.exception.ResourceNotFoundException;
 import kr.co.knowledgerally.core.lecture.entity.Form;
 import kr.co.knowledgerally.core.lecture.util.TestFormEntityFactory;
@@ -100,7 +102,7 @@ class FormServiceTest {
     @ExpectedDatabase(value = "classpath:dbunit/expected/crud/form_insert_test.xml",
             assertionMode = DatabaseAssertionMode.NON_STRICT)
     void 신청서_삽입_테스트() {
-        Form form = new TestFormEntityFactory().createEntity(7L, 4, 2);
+        Form form = new TestFormEntityFactory().createEntity(8L, 4, 3);
         formService.saveForm(form);
     }
     
@@ -119,5 +121,32 @@ class FormServiceTest {
         assertTrue(forms.get(0).isActive());
         assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 18), forms.get(0).getCreatedAt());
         assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 18), forms.get(0).getUpdatedAt());
+    }
+
+    @Test
+    void 클래스_코치로_신청서_목록_찾기_테스트() {
+        Coach coach = new TestCoachEntityFactory().createEntity(2L);
+
+        List<Form> forms = formService.findAllByLectureCoach(coach);
+
+        assertEquals(2, forms.size());
+
+        assertEquals(7L, forms.get(0).getId());
+        assertEquals(4L, forms.get(0).getLecture().getId());
+        assertEquals(2L, forms.get(0).getUser().getId());
+        assertEquals("신청서를 받아주세요!", forms.get(0).getContent());
+        assertEquals(Form.State.REQUEST, forms.get(0).getState());
+        assertTrue(forms.get(0).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 51, 5), forms.get(0).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 51, 6), forms.get(0).getUpdatedAt());
+
+        assertEquals(4L, forms.get(1).getId());
+        assertEquals(4L, forms.get(1).getLecture().getId());
+        assertEquals(1L, forms.get(1).getUser().getId());
+        assertEquals("신청서를 받아주세요!", forms.get(1).getContent());
+        assertEquals(Form.State.REQUEST, forms.get(1).getState());
+        assertTrue(forms.get(1).isActive());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 20), forms.get(1).getCreatedAt());
+        assertEquals(LocalDateTime.of(2022, 6, 13, 22, 48, 20), forms.get(1).getUpdatedAt());
     }
 }

--- a/knowlly-core/src/test/resources/dbunit/entity/form.xml
+++ b/knowlly-core/src/test/resources/dbunit/entity/form.xml
@@ -12,5 +12,6 @@
           created_at="2022-06-13 22:51:03" updated_at="2022-06-13 22:51:04"/>
     <form id="6" lecture_id="3" user_id="4" content="신청합니다!" state="REQUEST" is_active="true"
           created_at="2022-06-13 22:51:04" updated_at="2022-06-13 22:51:05"/>
-
+    <form id="7" lecture_id="4" user_id="2" content="신청서를 받아주세요!" state="REQUEST" is_active="true"
+          created_at="2022-06-13 22:51:05" updated_at="2022-06-13 22:51:06"/>
 </dataset>

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/form_delete_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/form_delete_test.xml
@@ -10,5 +10,6 @@
           created_at="2022-06-13 22:51:03" updated_at="2022-06-13 22:51:04"/>
     <form id="6" lecture_id="3" user_id="4" content="신청합니다!" state="REQUEST" is_active="true"
           created_at="2022-06-13 22:51:04" updated_at="2022-06-13 22:51:05"/>
-
+    <form id="7" lecture_id="4" user_id="2" content="신청서를 받아주세요!" state="REQUEST" is_active="true"
+          created_at="2022-06-13 22:51:05" updated_at="2022-06-13 22:51:06"/>
 </dataset>

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/form_insert_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/form_insert_test.xml
@@ -6,6 +6,7 @@
     <form id="4" lecture_id="4" user_id="1" content="신청서를 받아주세요!" state="REQUEST" is_active="true" />
     <form id="5" lecture_id="3" user_id="3" content="신청 거절해주세요" state="REJECT" is_active="true" />
     <form id="6" lecture_id="3" user_id="4" content="신청합니다!" state="REQUEST" is_active="true" />
-    <form id="7" lecture_id="4" user_id="2" content="테스트7의 신청 내용" state="REQUEST" is_active="true" />
+    <form id="7" lecture_id="4" user_id="2" content="신청서를 받아주세요!" state="REQUEST" is_active="true" />
+    <form id="8" lecture_id="4" user_id="3" content="테스트8의 신청 내용" state="REQUEST" is_active="true" />
 
 </dataset>

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/form_update_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/form_update_test.xml
@@ -12,5 +12,7 @@
           created_at="2022-06-13 22:51:03" />
     <form id="6" lecture_id="3" user_id="4" content="신청합니다!" state="REQUEST" is_active="true"
           created_at="2022-06-13 22:51:04" />
+    <form id="7" lecture_id="4" user_id="2" content="신청서를 받아주세요!" state="REQUEST" is_active="true"
+          created_at="2022-06-13 22:51:05" />
 
 </dataset>

--- a/knowlly-core/src/test/resources/sql/integration.sql
+++ b/knowlly-core/src/test/resources/sql/integration.sql
@@ -81,4 +81,5 @@ INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at
 INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (4, 4, 1, '신청서를 받아주세요!', 'REQUEST', true, '2022-06-13 22:48:20', '2022-06-13 22:48:20');
 INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (5, 3, 3, '신청 거절해주세요', 'REJECT', true, '2022-06-13 22:51:03', '2022-06-13 22:51:04');
 INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (6, 3, 4, '신청합니다!', 'REQUEST', true, '2022-06-13 22:51:04', '2022-06-13 22:51:05');
+INSERT INTO form (id, lecture_id, user_id, content, state, is_active, created_at, updated_at) VALUES (7, 4, 2, '신청서를 받아주세요!', 'REQUEST', true, '2022-06-13 22:51:05', '2022-06-13 22:51:06');
 


### PR DESCRIPTION
## 작업 내용 설명
- 운영 클래스 조회 응답 포맷 수정
- 그 외 신청서 수락시 이외의 신청서 거절 로직 추가

## 주요 변경 사항
- 운영 클래스 조회 응답 포맷 수정
- 그 외 신청서 수락시 이외의 신청서 거절 로직 추가
- 테스트 추가 및 보완

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #119

