### PR TITLE
[수정] CoachLecture 내부 matchedUser 자료형 변경 (#127)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/CoachLectureMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/CoachLectureMapper.java
@@ -1,10 +1,12 @@
 package kr.co.knowledgerally.api.lecture.component;
 
 import kr.co.knowledgerally.api.lecture.dto.CoachLectureDto;
+import kr.co.knowledgerally.api.user.component.UserMapper;
 import kr.co.knowledgerally.core.lecture.entity.Lecture;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -14,13 +16,16 @@ import java.time.format.DateTimeFormatter;
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
         uses = {LectureMapper.class, LectureInformationMapper.class, FormMapper.class}
 )
-public interface CoachLectureMapper {
+public abstract class CoachLectureMapper {
+    @Autowired
+    protected UserMapper userMapper;
+
     @Mapping(target = "lecture", source = "lecture")
     @Mapping(target = "lectureInformation", source = "lecture.lectureInformation")
     @Mapping(target = "forms", source = "lecture.forms")
     @Mapping(target = "isMatched", expression = "java(lecture.getState() != " +
             "kr.co.knowledgerally.core.lecture.entity.Lecture.State.ON_BOARD)")
     @Mapping(target = "matchedUser", expression = "java(lecture.getState() != " + // forms에는 매칭된 사람 신청서만 있다는 전제조건을 깔고 감
-            "kr.co.knowledgerally.core.lecture.entity.Lecture.State.ON_BOARD ? lecture.getForms().get(0).getUser() : null)")
-    CoachLectureDto toDto(Lecture lecture);
+            "kr.co.knowledgerally.core.lecture.entity.Lecture.State.ON_BOARD ? userMapper.toDto(lecture.getForms().get(0).getUser()) : null)")
+    public abstract CoachLectureDto toDto(Lecture lecture);
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/FormMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/FormMapper.java
@@ -2,12 +2,15 @@ package kr.co.knowledgerally.api.lecture.component;
 
 import kr.co.knowledgerally.api.lecture.dto.FormDto;
 import kr.co.knowledgerally.api.lecture.dto.LectureDto;
+import kr.co.knowledgerally.api.user.component.UserImageMapper;
 import kr.co.knowledgerally.api.user.component.UserMapper;
 import kr.co.knowledgerally.core.lecture.entity.Form;
 import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import kr.co.knowledgerally.core.user.service.UserImageService;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -17,8 +20,15 @@ import java.time.format.DateTimeFormatter;
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
         uses = { UserMapper.class, LectureMapper.class }
 )
-public interface FormMapper {
+public abstract class FormMapper {
+    @Autowired
+    protected UserImageMapper userImageMapper;
+
+    @Autowired
+    protected UserImageService userImageService;
+
     @Mapping(target = "expirationDate", expression = "java(form.getExpirationDate().toString())")
-    FormDto.ReadOnly toDto(Form form);
-    Form toEntity(FormDto lectureDto);
+    @Mapping(target = "userImage", expression = "java(userImageMapper.toDto(userImageService.findByUser(form.getUser())))")
+    public abstract FormDto.ReadOnly toDto(Form form);
+    public abstract Form toEntity(FormDto lectureDto);
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/CoachLectureDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/CoachLectureDto.java
@@ -3,6 +3,7 @@ package kr.co.knowledgerally.api.lecture.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import kr.co.knowledgerally.api.user.dto.UserDto;
 import kr.co.knowledgerally.core.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -57,7 +58,7 @@ public class CoachLectureDto {
             accessMode = ApiModelProperty.AccessMode.READ_ONLY
     )
     @JsonProperty(index = PropertyDisplayOrder.MATCHED_USER)
-    private User matchedUser;
+    private UserDto.ReadOnly matchedUser;
 
     private static class PropertyDisplayOrder {
         private static final int LECTURE = 0;

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/FormDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/FormDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.api.user.dto.UserImageDto;
 import kr.co.knowledgerally.core.lecture.entity.Form;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -52,6 +53,10 @@ public class FormDto {
         )
         @JsonProperty(index = PropertyDisplayOrder.USER)
         private UserDto.ReadOnly user;
+
+        @ApiModelProperty(value = "신청자 프로필 이미지", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @JsonProperty
+        private UserImageDto userImage;
 
         @ApiModelProperty(
                 value = "클래스 일정 현재 상태 \n" +

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserProfileDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserProfileDto.java
@@ -13,15 +13,15 @@ import lombok.*;
 @AllArgsConstructor
 @ApiModel(value = "사용자 프로필 모델", description = "사용자 프로필 모델")
 public class UserProfileDto {
-    @ApiModelProperty(value = "사용자 프로필")
+    @ApiModelProperty(value = "사용자 프로필", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
     @JsonProperty
     private UserDto.ReadOnly user;
 
-    @ApiModelProperty(value = "프로필 이미지")
+    @ApiModelProperty(value = "프로필 이미지", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
     @JsonProperty
     private UserImageDto userImage;
 
-    @ApiModelProperty(value = "코치 정보, 코치 아닐시 null")
+    @ApiModelProperty(value = "코치 정보, 코치 아닐시 null", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
     @JsonProperty
     private CoachDto.ReadOnly coach;
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/FormMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/FormMapperTest.java
@@ -5,19 +5,28 @@ import kr.co.knowledgerally.api.lecture.util.TestFormDtoFactory;
 import kr.co.knowledgerally.core.core.util.TestEntityFactory;
 import kr.co.knowledgerally.core.lecture.entity.Form;
 import kr.co.knowledgerally.core.lecture.util.TestFormEntityFactory;
+import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.service.UserImageService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class FormMapperTest {
     @Autowired
     FormMapper formMapper;
 
+    @MockBean
+    UserImageService userImageService;
+
     @Test
     void 엔티티에서_DTO변환_테스트() {
+        when(userImageService.findByUser(any())).thenReturn(UserImage.builder().userImgUrl("http://test4.img.url").build());
         Form form = new TestFormEntityFactory().createEntity(1L, 1L, 4L);
 
         FormDto.ReadOnly formDto = formMapper.toDto(form);
@@ -25,6 +34,7 @@ class FormMapperTest {
         assertEquals(1L, formDto.getId());
         assertEquals(1L, formDto.getLecture().getId());
         assertEquals(4L, formDto.getUser().getId());
+        assertEquals("http://test4.img.url", formDto.getUserImage().getUserImgUrl());
         assertEquals("테스트1의 신청 내용", formDto.getContent());
         assertEquals(Form.State.REQUEST, formDto.getState());
         assertEquals("2022-06-16T22:48:17", formDto.getExpirationDate());

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CoachLectureControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/web/CoachLectureControllerTest.java
@@ -24,6 +24,7 @@ class CoachLectureControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lecture.state").value("ON_BOARD"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].lectureInformation.id").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].forms[0].id").value(6))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].forms[0].userImage.userImgUrl").value("http://test4.img.url"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].matched").value(false))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].matchedUser").isEmpty())
 


### PR DESCRIPTION
## 작업 내용 설명
- CoachLecture 내부 matchedUser 자료형 변경

## 주요 변경 사항
- CoachLecture 내부 matchedUser 자료형 변경

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #127

@NaLDo627 @Park-Young-Hun
