### PR TITLE
Fix: UserDto, CoachDto 필드 추가 (#134)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/component/CoachMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/component/CoachMapper.java
@@ -4,14 +4,42 @@ import kr.co.knowledgerally.api.coach.dto.CoachDto;
 import kr.co.knowledgerally.api.user.component.UserMapper;
 import kr.co.knowledgerally.api.user.dto.UserDto;
 import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.repository.ReviewRepository;
+import kr.co.knowledgerally.core.coach.service.ReviewService;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import kr.co.knowledgerally.core.lecture.entity.LectureInformation;
+import kr.co.knowledgerally.core.lecture.repository.LectureRepository;
+import kr.co.knowledgerally.core.lecture.service.LectureInformationService;
+import kr.co.knowledgerally.core.lecture.service.LectureService;
 import kr.co.knowledgerally.core.user.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 
 @Mapper(componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
         uses = { UserMapper.class })
-public interface CoachMapper {
-    CoachDto.ReadOnly toDto(Coach user);
+public abstract class CoachMapper {
+    @Autowired
+    private LectureRepository lectureRepository;
+
+    @Autowired
+    private ReviewService reviewService;
+
+    @Mapping(target = "currentLectureCount", expression = "java( countOnGoingLectures(coach) )")
+    @Mapping(target = "reviewCount", expression = "java( countReviews(coach) )")
+    public abstract CoachDto.ReadOnly toDto(Coach coach);
+
+    protected int countOnGoingLectures(Coach coach) {
+        return (int) lectureRepository.findAllByCoach(coach).stream()
+                .filter(x -> x.getState() != Lecture.State.DONE)
+                .count();
+    }
+
+    protected int countReviews(Coach coach) {
+        return (int) reviewService.findAllByRevieweeWithPageable(coach, Pageable.unpaged())
+                .getTotalElements();
+    }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/dto/CoachDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/coach/dto/CoachDto.java
@@ -22,8 +22,7 @@ import javax.persistence.OneToOne;
 @AllArgsConstructor
 @ApiModel(value = "코치 모델", description = "코치를 나타내는 모델")
 public class CoachDto {
-    @ApiModelProperty(value = "코치 소개", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
-            position = PropertyDisplayOrder.INTRODUCE)
+    @ApiModelProperty(value = "코치 소개", position = PropertyDisplayOrder.INTRODUCE)
     @JsonProperty(index = PropertyDisplayOrder.INTRODUCE)
     private String introduce;
 
@@ -43,11 +42,23 @@ public class CoachDto {
                 position = PropertyDisplayOrder.USER)
         @JsonProperty(index = PropertyDisplayOrder.USER)
         private UserDto.ReadOnly user;
+
+        @ApiModelProperty(value = "매칭중, 혹은 운영 중인 클래스 갯수", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.ON_GOING_LECTURE_COUNT)
+        @JsonProperty(index = PropertyDisplayOrder.ON_GOING_LECTURE_COUNT)
+        private int currentLectureCount;
+
+        @ApiModelProperty(value = "코치에게 달린 후기 갯수", accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.REVIEW_COUNT)
+        @JsonProperty(index = PropertyDisplayOrder.REVIEW_COUNT)
+        private int reviewCount;
     }
 
     private static class PropertyDisplayOrder {
         private static final int ID = 0;
         private static final int INTRODUCE = 1;
         private static final int USER = 2;
+        private static final int ON_GOING_LECTURE_COUNT = 3;
+        private static final int REVIEW_COUNT = 4;
     }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/FormDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/FormDto.java
@@ -54,7 +54,8 @@ public class FormDto {
         @JsonProperty(index = PropertyDisplayOrder.USER)
         private UserDto.ReadOnly user;
 
-        @ApiModelProperty(value = "신청자 프로필 이미지", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+        @Deprecated
+        @ApiModelProperty(value = "신청자 프로필 이미지 (삭제 예정)", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
         @JsonProperty
         private UserImageDto userImage;
 

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/component/UserMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/component/UserMapper.java
@@ -1,19 +1,31 @@
 package kr.co.knowledgerally.api.user.component;
 
 import kr.co.knowledgerally.api.user.dto.UserDto;
+import kr.co.knowledgerally.api.user.dto.UserImageDto;
 import kr.co.knowledgerally.core.user.entity.User;
 import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.service.UserImageService;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.format.DateTimeFormatter;
 
 @Mapper(componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public interface UserMapper {
+public abstract class UserMapper {
+    @Autowired
+    protected UserImageService userImageService;
+
     @Mapping(target = "isCoach", source = "user.coach")
     @Mapping(target = "isPushActive", source = "user.pushActive")
-    UserDto.ReadOnly toDto(User user);
-    User toEntity(UserDto userDto);
+    @Mapping(target = "userImgUrl", expression = "java( findAndMapUserImage(user) )")
+    public abstract UserDto.ReadOnly toDto(User user);
+    public abstract User toEntity(UserDto userDto);
+
+    protected String findAndMapUserImage(User user) {
+        UserImage userImage = userImageService.findByUser(user);
+        return userImage == null ? null : userImage.getUserImgUrl();
+    }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserDto.java
@@ -66,6 +66,10 @@ public class UserDto {
         @ApiModelProperty(value = "사용자 식별값", position = PropertyDisplayOrder.IDENTIFIER)
         @JsonProperty(index = PropertyDisplayOrder.IDENTIFIER)
         private String identifier;
+
+        @ApiModelProperty(value = "사용자 대표 이미지", position = PropertyDisplayOrder.USER_IMG_URL)
+        @JsonProperty(index = PropertyDisplayOrder.USER_IMG_URL)
+        private String userImgUrl;
     }
 
     private static class PropertyDisplayOrder {
@@ -78,5 +82,6 @@ public class UserDto {
         private static final int IDENTIFIER = 6;
         private static final int IS_COACH = 7;
         private static final int IS_PUSH_ACTIVE = 8;
+        private static final int USER_IMG_URL = 9;
     }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserProfileDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/user/dto/UserProfileDto.java
@@ -17,7 +17,8 @@ public class UserProfileDto {
     @JsonProperty
     private UserDto.ReadOnly user;
 
-    @ApiModelProperty(value = "프로필 이미지", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
+    @Deprecated
+    @ApiModelProperty(value = "프로필 이미지 (삭제 예정)", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
     @JsonProperty
     private UserImageDto userImage;
 

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/coach/component/CoachMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/coach/component/CoachMapperTest.java
@@ -2,20 +2,44 @@ package kr.co.knowledgerally.api.coach.component;
 
 import kr.co.knowledgerally.api.coach.dto.CoachDto;
 import kr.co.knowledgerally.core.coach.entity.Coach;
+import kr.co.knowledgerally.core.coach.service.ReviewService;
 import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
+import kr.co.knowledgerally.core.lecture.entity.Lecture;
+import kr.co.knowledgerally.core.lecture.repository.LectureRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class CoachMapperTest {
     @Autowired
     CoachMapper coachMapper;
 
+    @MockBean
+    LectureRepository lectureRepository;
+
+    @MockBean
+    ReviewService reviewService;
+
     @Test
     void 엔티티에서_DTO변환_테스트() {
+        when(lectureRepository.findAllByCoach(any()))
+                .thenReturn(List.of(
+                        Lecture.builder().state(Lecture.State.ON_BOARD).build(),
+                        Lecture.builder().state(Lecture.State.ON_GOING).build(),
+                        Lecture.builder().state(Lecture.State.DONE).build()
+                ));
+        when(reviewService.findAllByRevieweeWithPageable(any() , any()))
+                .thenReturn(Page.empty());
+
         Coach coach = new TestCoachEntityFactory().createEntity(1L, 1L);
 
         CoachDto.ReadOnly coachDto = coachMapper.toDto(coach);
@@ -30,5 +54,7 @@ class CoachMapperTest {
         assertEquals("identifier1", coachDto.getUser().getIdentifier());
         assertFalse(coachDto.getUser().isCoach());
         assertTrue(coachDto.getUser().isPushActive());
+        assertEquals(2, coachDto.getCurrentLectureCount());
+        assertEquals(0, coachDto.getReviewCount());
     }
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/UserMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/component/UserMapperTest.java
@@ -4,25 +4,35 @@ import kr.co.knowledgerally.api.user.dto.UserDto;
 import kr.co.knowledgerally.api.user.util.TestUserDtoFactory;
 import kr.co.knowledgerally.core.user.entity.User;
 import kr.co.knowledgerally.core.user.entity.UserImage;
+import kr.co.knowledgerally.core.user.service.UserImageService;
 import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
 import kr.co.knowledgerally.core.user.util.TestUserImageEntityFactory;
 import liquibase.pro.packaged.T;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class UserMapperTest {
     @Autowired
     private UserMapper userMapper;
 
+    @MockBean
+    private UserImageService userImageService;
+
     @Test
     void 엔티티에서_DTO변환_테스트() {
         User user = new TestUserEntityFactory().createEntity(1L);
+        when(userImageService.findByUser(any()))
+                .thenReturn(new TestUserImageEntityFactory().createEntity(1L));
 
         UserDto.ReadOnly userDto = userMapper.toDto(user);
+
         assertEquals(1L, userDto.getId());
         assertEquals("테스트1", userDto.getUsername());
         assertEquals(1, userDto.getBallCnt());
@@ -32,6 +42,7 @@ class UserMapperTest {
         assertEquals("identifier1", userDto.getIdentifier());
         assertFalse(userDto.isCoach());
         assertTrue(userDto.isPushActive());
+        assertEquals("http://test1.userimg.url", userDto.getUserImgUrl());
     }
 
     @Test

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserMeControllerTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/user/web/UserMeControllerTest.java
@@ -27,8 +27,10 @@ class UserMeControllerTest extends AbstractControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.kakaoId").value("kakao_test1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.portfolio").value("포트폴리오1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.identifier").value("identifier1"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.userImage.userImgUrl").value("http://test1.img.url"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.user.userImgUrl").value("http://test1.img.url"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.coach.introduce").value("안녕하세요. 테스트1 코치입니다."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.coach.currentLectureCount").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.coach.reviewCount").value(2))
                 .andDo(print());
     }
 


### PR DESCRIPTION
## 작업 내용 설명
- UserDto - 유저 프로필 이미지 경로 필드 추가
- CoachDto - 운영중인 클래스, 후기 갯수 필드 추가

## 주요 변경 사항
- UserDto 변경 및 매핑 로직 수정
- CoachDto 변경 및 매핑 로직 수정
- 테스트 수정

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #134

@NaLDo627 @Park-Young-Hun
