### PR TITLE
[수정] TagDto, LectureImageDto ReadOnly 객체 분리 (#137)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/LectureImageMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/LectureImageMapper.java
@@ -7,6 +7,6 @@ import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface LectureImageMapper {
-    LectureImageDto toDto(LectureImage lectureImage);
+    LectureImageDto.ReadOnly toDto(LectureImage lectureImage);
     LectureImage toEntity(LectureImageDto lectureImageDto);
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/TagMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/TagMapper.java
@@ -7,6 +7,6 @@ import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface TagMapper {
-    TagDto toDto(Tag tag);
+    TagDto.ReadOnly toDto(Tag tag);
     Tag toEntity(TagDto tagDto);
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/LectureImageDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/LectureImageDto.java
@@ -17,11 +17,27 @@ import lombok.experimental.SuperBuilder;
 @ApiModel(value = "클래스 이미지 모델", description = "클래스 이미지를 나타내는 모델")
 public class LectureImageDto {
 
-    @ApiModelProperty(value = "클래스 이미지 id")
-    @JsonProperty
+    @ApiModelProperty(value = "클래스 이미지 id", position = PropertyDisplayOrder.ID)
+    @JsonProperty(index = PropertyDisplayOrder.ID)
     private Long id;
+    @SuperBuilder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value = "클래스 이미지 읽기 모델", description = "읽기 전용 클래스 이미지 모델")
+    public static class ReadOnly extends LectureImageDto {
+        @ApiModelProperty(
+                value = "클래스 이미지 경로",
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY,
+                position = PropertyDisplayOrder.IMAGE
+        )
+        @JsonProperty(index = PropertyDisplayOrder.IMAGE)
+        private String lectureImgUrl;
+    }
 
-    @ApiModelProperty(value = "클래스 이미지 경로", accessMode = ApiModelProperty.AccessMode.READ_ONLY)
-    @JsonProperty
-    private String lectureImgUrl;
+    private static class PropertyDisplayOrder {
+        private static final int ID = 0;
+        private static final int IMAGE = 1;
+    }
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/TagDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/TagDto.java
@@ -13,17 +13,26 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @ApiModel(value = "태그 모델", description = "태그 모델")
 public class TagDto {
-    @ApiModelProperty(
-            value = "태그 id",
-            position = PropertyDisplayOrder.ID,
-            accessMode = ApiModelProperty.AccessMode.READ_ONLY
-    )
-    @JsonProperty(index = PropertyDisplayOrder.ID)
-    private Long id;
 
     @ApiModelProperty(value = "태그 내용", position = PropertyDisplayOrder.CONTENT)
     @JsonProperty(index = PropertyDisplayOrder.CONTENT)
     private String content;
+
+    @SuperBuilder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value = "태그 읽기 모델", description = "읽기 전용 태그 모델")
+    public static class ReadOnly extends TagDto {
+        @ApiModelProperty(
+                value = "태그 id",
+                position = PropertyDisplayOrder.ID,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.ID)
+        private Long id;
+    }
 
     private static class PropertyDisplayOrder {
         private static final int ID = 0;

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/LectureImageMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/LectureImageMapperTest.java
@@ -23,7 +23,7 @@ public class LectureImageMapperTest {
     void 엔티티에서_DTO변환_테스트() {
         LectureImage lectureImage = new TestLectureImageEntityFactory().createEntity(1L);
 
-        LectureImageDto lectureImageDto = lectureImageMapper.toDto(lectureImage);
+        LectureImageDto.ReadOnly lectureImageDto = lectureImageMapper.toDto(lectureImage);
         assertEquals("http://lecture1.img.url", lectureImageDto.getLectureImgUrl());
     }
 
@@ -32,7 +32,7 @@ public class LectureImageMapperTest {
         LectureImageDto lectureImageDto = new TestLectureImageDtoFactory().createDto(1L);
 
         LectureImage lectureImage = lectureImageMapper.toEntity(lectureImageDto);
-        assertEquals("http://lecture.img1.url", lectureImage.getLectureImgUrl());
+        assertEquals(1, lectureImage.getId());
     }
 
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestLectureImageDtoFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestLectureImageDtoFactory.java
@@ -17,7 +17,6 @@ public class TestLectureImageDtoFactory implements TestDtoFactory<LectureImageDt
     public LectureImageDto createDto(long id) {
         return LectureImageDto.builder()
                 .id(id)
-                .lectureImgUrl(String.format("http://lecture.img%d.url", id))
                 .build();
     }
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestTagDtoFactory.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/util/TestTagDtoFactory.java
@@ -14,8 +14,8 @@ public class TestTagDtoFactory implements TestDtoFactory<TagDto> {
      * @return 생성된 태그 Dto
      */
     @Override
-    public TagDto createDto(long id) {
-        return TagDto.builder()
+    public TagDto.ReadOnly createDto(long id) {
+        return TagDto.ReadOnly.builder()
                 .id(id)
                 .content(String.format("테스트 내용%d", id))
                 .build();


### PR DESCRIPTION
## 작업 내용 설명
- TagDto, LectureImageDto ReadOnly 객체 분리

## 주요 변경 사항
- TagDto, LectureImageDto ReadOnly 객체 분리

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #137

@NaLDo627 @Park-Young-Hun
