### PR TITLE
[수정] 클래스-info 등록시 user.coach를 true로 저장 (#140)

### DIFF
--- a/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/LectureInformationService.java
+++ b/knowlly-core/src/main/java/kr/co/knowledgerally/core/lecture/service/LectureInformationService.java
@@ -13,7 +13,10 @@ import kr.co.knowledgerally.core.lecture.repository.LectureImageRepository;
 import kr.co.knowledgerally.core.lecture.repository.LectureInformationRepository;
 import kr.co.knowledgerally.core.lecture.repository.TagRepository;
 import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.repository.UserRepository;
+import kr.co.knowledgerally.core.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -35,6 +38,7 @@ public class LectureInformationService {
     private final LectureImageRepository lectureImageRepository;
     private final CoachService coachService;
     private final CategoryService categoryService;
+    private final UserRepository userRepository;
 
     /**
      * 클래스-info 목록을 조회합니다.
@@ -134,6 +138,7 @@ public class LectureInformationService {
             coach.setIntroduce(user.getIntro());
             user.setCoach(true);
             coachRepository.save(coach);
+            userRepository.save(user);
         }
         return coach;
     }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/LectureInformationServiceTest.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/service/LectureInformationServiceTest.java
@@ -11,6 +11,8 @@ import kr.co.knowledgerally.core.lecture.entity.LectureInformation;
 import kr.co.knowledgerally.core.lecture.entity.Tag;
 import kr.co.knowledgerally.core.lecture.util.TestCategoryEntityFactory;
 import kr.co.knowledgerally.core.lecture.util.TestLectureInformationEntityFactory;
+import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.util.TestUserEntityFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -41,6 +43,7 @@ public class LectureInformationServiceTest {
 
     TestLectureInformationEntityFactory testLectureInformationEntityFactory = new TestLectureInformationEntityFactory();
     TestCategoryEntityFactory testCategoryEntityFactory = new TestCategoryEntityFactory();
+    TestUserEntityFactory testUserEntityFactory = new TestUserEntityFactory();
 
     @Test
     void 클래스_info_목록_조회() {
@@ -126,5 +129,23 @@ public class LectureInformationServiceTest {
         lectureInformation.setTags(tagSet);
         lectureInformation.setCategory(Category.builder().name(Category.Name.LANGUAGE).build());
         lectureInformationService.saveLectureInformation(lectureInformation, lectureInformation.getCoach().getUser());
+    }
+
+    @Test
+//    @ExpectedDatabase(value = "classpath:dbunit/expected/crud/lecture_information_insert_test.xml",
+//            assertionMode = DatabaseAssertionMode.NON_STRICT)
+    void 가입후_첫_클래스_info와_클래스_태그_등록() {
+        Set<Tag> tagSet = new LinkedHashSet<>();
+
+        tagSet.add(Tag.builder().content("테스트 내용6").build());
+        tagSet.add(Tag.builder().content("테스트 내용7").build());
+
+        LectureInformation lectureInformation = testLectureInformationEntityFactory.createEntityWithoutCoach(6L, 2L,2);
+        lectureInformation.setTags(tagSet);
+        lectureInformation.setCategory(Category.builder().name(Category.Name.LANGUAGE).build());
+        User user = testUserEntityFactory.createEntity(2L);
+        assertFalse(user.isCoach());
+        LectureInformation newLectureInfo = lectureInformationService.saveLectureInformation(lectureInformation, user);
+        assertTrue(newLectureInfo.getCoach().getUser().isCoach());
     }
 }

--- a/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/util/TestLectureInformationEntityFactory.java
+++ b/knowlly-core/src/test/java/kr/co/knowledgerally/core/lecture/util/TestLectureInformationEntityFactory.java
@@ -1,5 +1,6 @@
 package kr.co.knowledgerally.core.lecture.util;
 
+import kr.co.knowledgerally.core.coach.entity.Coach;
 import kr.co.knowledgerally.core.core.util.TestEntityFactory;
 import kr.co.knowledgerally.core.lecture.entity.*;
 import kr.co.knowledgerally.core.coach.util.TestCoachEntityFactory;
@@ -61,6 +62,44 @@ public class TestLectureInformationEntityFactory implements TestEntityFactory<Le
         return LectureInformation.builder()
                 .id(entityId)
                 .coach(testCoachEntityFactory.createEntity(coachId, userId))
+                .category(testCategoryEntityFactory.createEntity(categoryId))
+                .lectureImages(lectureImages)
+                .tags(tags)
+                .lectures(lectures)
+                .topic(String.format("테스트%d 제목", entityId))
+                .introduce(String.format("안녕하세요. 테스트%d 입니다.", entityId))
+                .price(1)
+                .build();
+    }
+
+    public LectureInformation createEntityWithoutCoach(long entityId, long categoryId, long lectureImageNum) {
+        Set<LectureImage> lectureImages = new LinkedHashSet<>();
+        Set<Tag> tags = new LinkedHashSet<>();
+        List<Lecture> lectures = new ArrayList<>();
+
+        tags.add(Tag.builder()
+                .lectureInformation(LectureInformation.builder().build())
+                .build());
+
+        lectures.add(Lecture.builder()
+                .lectureInformation(LectureInformation.builder().build())
+                .startAt(LocalDateTime.of(2022, 6, 15, 10, 30, 50))
+                .endAt(LocalDateTime.of(2022, 6, 15, 11, 30, 50))
+                .build());
+
+        for (long index=1; index<=lectureImageNum; index++) {
+            lectureImages.add(
+                    LectureImage.builder()
+                            .id(index)
+                            .lectureInformation(LectureInformation.builder().build())
+                            .lectureImgUrl(String.format("http://lecture%d.img%d.url", entityId, index))
+                            .build()
+            );
+        }
+
+        return LectureInformation.builder()
+                .id(entityId)
+                .coach(Coach.builder().build())
                 .category(testCategoryEntityFactory.createEntity(categoryId))
                 .lectureImages(lectureImages)
                 .tags(tags)

--- a/knowlly-core/src/test/resources/dbunit/expected/crud/lecture_information_insert_test.xml
+++ b/knowlly-core/src/test/resources/dbunit/expected/crud/lecture_information_insert_test.xml
@@ -10,6 +10,6 @@
                          price="1" is_active="false" />
     <lecture_information id="5" coach_id="1" category_id="6" topic="요리 클래스" introduce="맛있는 요리 만들기" price="1"
                          is_active="true" />
-    <lecture_information id="6" coach_id="2" category_id="5" topic="테스트6 제목" introduce="안녕하세요. 테스트6 입니다." price="1"
+    <lecture_information id="6" coach_id="5" category_id="5" topic="테스트6 제목" introduce="안녕하세요. 테스트6 입니다." price="1"
                          is_active="true" />
 </dataset>


### PR DESCRIPTION
## 작업 내용 설명
- 클래스-info 등록시 user.coach를 true로 저장

## 주요 변경 사항
-클래스-info 등록시 user.coach를 true로 저장

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #140

@NaLDo627 @Park-Young-Hun
