### PR TITLE
[수정] FormDto에 클래스 일정 정보 추가 (#144)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/FormMapper.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/component/FormMapper.java
@@ -29,6 +29,8 @@ public abstract class FormMapper {
 
     @Mapping(target = "expirationDate", expression = "java(form.getExpirationDate().toString())")
     @Mapping(target = "userImage", expression = "java(userImageMapper.toDto(userImageService.findByUser(form.getUser())))")
+    @Mapping(target = "startAt", expression = "java(form.getLecture().getStartAt().toString())")
+    @Mapping(target = "endAt", expression = "java(form.getLecture().getEndAt().toString())")
     public abstract FormDto.ReadOnly toDto(Form form);
     public abstract Form toEntity(FormDto lectureDto);
 }

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/FormDto.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/lecture/dto/FormDto.java
@@ -62,19 +62,36 @@ public class FormDto {
         @JsonProperty(index = PropertyDisplayOrder.STATE)
         private Form.State state;
 
-        @ApiModelProperty(value = "신청 내용",
+        @ApiModelProperty(value = "만료일",
                 position = PropertyDisplayOrder.EXPIRATION_DATE,
                 accessMode = ApiModelProperty.AccessMode.READ_ONLY)
         @JsonProperty(index = PropertyDisplayOrder.EXPIRATION_DATE)
         private String expirationDate;
+
+        @ApiModelProperty(
+                value = "클래스 일정 시작 시간",
+                position = PropertyDisplayOrder.LECTURE_START,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.LECTURE_START)
+        private String startAt;
+
+        @ApiModelProperty(
+                value = "클래스 일정 시작 시간",
+                position = PropertyDisplayOrder.LECTURE_END,
+                accessMode = ApiModelProperty.AccessMode.READ_ONLY
+        )
+        @JsonProperty(index = PropertyDisplayOrder.LECTURE_END)
+        private String endAt;
     }
 
     private static class PropertyDisplayOrder {
         private static final int ID = 0;
         private static final int CONTENT = 1;
-        private static final int LECTURE = 2;
         private static final int USER = 3;
         private static final int STATE = 4;
         private static final int EXPIRATION_DATE = 5;
+        private static final int LECTURE_START = 6;
+        private static final int LECTURE_END = 7;
     }
 }

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/FormMapperTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/lecture/component/FormMapperTest.java
@@ -37,6 +37,8 @@ class FormMapperTest {
         assertEquals("테스트1의 신청 내용", formDto.getContent());
         assertEquals(Form.State.REQUEST, formDto.getState());
         assertEquals("2022-06-16T22:48:17", formDto.getExpirationDate());
+        assertEquals("2022-06-15T10:30:50", formDto.getStartAt());
+        assertEquals("2022-06-15T11:30:50", formDto.getEndAt());
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용 설명
- FormDto 에 LectureDto를 끼우게 되면 순환 참조 일어나서 StackOverflow 에러남
- 필요한게 startAt, endAt 정보이므로 그 정보를 따로 매핑하는것으로 해결

## 주요 변경 사항
- FormDto 수정
- FormMapper 수정
- 테스트 수정

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #144

@NaLDo627 @Park-Young-Hun
