### PR TITLE
[수정] 리프레시 토큰 로직 수정 (#76)

### DIFF
--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtCreator.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/component/JwtCreator.java
@@ -18,9 +18,12 @@ import java.util.Date;
  */
 @Component
 @RequiredArgsConstructor
-public class JwtCreator { // TODO 유효시간 설정 외부 설정값으로 변경
-    private static final long ACCESS_TOKEN_VALID_MILISECOND = 1000 * 60 * 60 * 24; // 24 시간
-    private static final long REFRESH_TOKEN_VALID_MILISECOND = 1000L * 60 * 60 * 24 * 30 * 2; // 2달
+public class JwtCreator {
+    @Value("${spring.jwt.access-token-valid-miliseconds}")
+    private long ACCESS_TOKEN_VALID_MILISECONDS;
+
+    @Value("${spring.jwt.refresh-token-valid-miliseconds}")
+    private long REFRESH_TOKEN_VALID_MILISECONDS;
 
     @Value("${spring.jwt.secret}")
     private String secretKey;
@@ -38,7 +41,7 @@ public class JwtCreator { // TODO 유효시간 설정 외부 설정값으로 변
      * @return Jwt 토큰
      */
     public String createAccessToken(User user) {
-        return createToken(user, ACCESS_TOKEN_VALID_MILISECOND);
+        return createToken(user, ACCESS_TOKEN_VALID_MILISECONDS);
     }
 
     /**
@@ -47,7 +50,7 @@ public class JwtCreator { // TODO 유효시간 설정 외부 설정값으로 변
      * @return Jwt 토큰
      */
     public String createRefreshToken(User user) {
-        return createToken(user, REFRESH_TOKEN_VALID_MILISECOND);
+        return createToken(user, REFRESH_TOKEN_VALID_MILISECONDS);
     }
 
     private String createToken(User user, long expirationMilisecond) {

--- a/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/service/JwtService.java
+++ b/knowlly-api/src/main/java/kr/co/knowledgerally/api/core/jwt/service/JwtService.java
@@ -8,7 +8,9 @@ import kr.co.knowledgerally.api.core.jwt.dto.ProviderToken;
 import kr.co.knowledgerally.api.core.oauth2.service.OAuth2ServiceFactory;
 import kr.co.knowledgerally.core.core.component.DateFactory;
 import kr.co.knowledgerally.core.core.exception.UnauthorizedException;
+import kr.co.knowledgerally.core.user.entity.RefreshToken;
 import kr.co.knowledgerally.core.user.entity.User;
+import kr.co.knowledgerally.core.user.repository.RefreshTokenRepository;
 import kr.co.knowledgerally.core.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * JWT 관련 로직 서비스
@@ -29,6 +32,7 @@ public class JwtService {
     private final OAuth2ServiceFactory oAuth2ServiceFactory;
     private final UserService userService;
     private final DateFactory dateFactory;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     /**
      * JWT 토큰 발급
@@ -39,9 +43,13 @@ public class JwtService {
     public JwtToken issue(ProviderToken providerToken){
         String identifier = oAuth2ServiceFactory.getInstance(providerToken.getProviderName()).getProfile(providerToken.getProviderAccessToken()).getIdentifier();
         User user = userService.findByIdentifier(identifier);
+        RefreshToken refreshTokenFromDb = refreshTokenRepository.findByUser(user)
+                .orElse(RefreshToken.builder().user(user).build());
 
         String accessToken = jwtCreator.createAccessToken(user);
         String refreshToken = jwtCreator.createRefreshToken(user);
+        refreshTokenFromDb.setValue(refreshToken);
+        refreshTokenRepository.saveAndFlush(refreshTokenFromDb);
         return new JwtToken(accessToken, refreshToken);
     }
 
@@ -50,7 +58,7 @@ public class JwtService {
      * @param knowllyRefreshToken 리프레시 JWT 토큰
      * @return jwt 토큰
      */
-    @Transactional // TODO db 데이터와 대조하는 로직 필요
+    @Transactional
     public JwtToken refresh(JwtToken.Refresh knowllyRefreshToken){
         if (isExpired(knowllyRefreshToken)) {
             throw new UnauthorizedException("Refresh Token이 만료되었습니다. 다시 로그인 해주세요.");
@@ -58,18 +66,28 @@ public class JwtService {
 
         String identifier = jwtResolver.getUserIdentifier(knowllyRefreshToken.getKnowllyRefreshToken());
         User user = userService.findByIdentifier(identifier);
+        RefreshToken refreshTokenFromDb = refreshTokenRepository.findByUser(user)
+                .orElse(RefreshToken.builder().user(user).build());
+        if (isTokenNotMatchedWithDb(refreshTokenFromDb, knowllyRefreshToken)) {
+            throw new UnauthorizedException("Refresh Token이 DB값과 일치하지 않습니다. 다시 로그인 해주세요.");
+        }
 
         String accessToken = jwtCreator.createAccessToken(user);
         String refreshToken = knowllyRefreshToken.getKnowllyRefreshToken();
         if (isRefreshable(knowllyRefreshToken)) {
             refreshToken = jwtCreator.createRefreshToken(user);
         }
-
+        refreshTokenFromDb.setValue(refreshToken);
+        refreshTokenRepository.saveAndFlush(refreshTokenFromDb);
         return new JwtToken(accessToken, refreshToken);
     }
 
     private boolean isExpired(JwtToken.Refresh knowllyRefreshToken) {
         return ! jwtValidator.validateToken(knowllyRefreshToken.getKnowllyRefreshToken());
+    }
+
+    private boolean isTokenNotMatchedWithDb(RefreshToken refreshTokenFromDb, JwtToken.Refresh knowllyRefreshToken) {
+        return ! Objects.equals(refreshTokenFromDb.getValue(), knowllyRefreshToken.getKnowllyRefreshToken());
     }
 
     private boolean isRefreshable(JwtToken.Refresh knowllyRefreshToken) {

--- a/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/component/JwtCreatorTest.java
+++ b/knowlly-api/src/test/java/kr/co/knowledgerally/api/core/jwt/component/JwtCreatorTest.java
@@ -28,6 +28,8 @@ class JwtCreatorTest extends AbstractJwtTest {
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(jwtCreator, "secretKey", TEST_SECRET_KEY);
+        ReflectionTestUtils.setField(jwtCreator, "ACCESS_TOKEN_VALID_MILISECONDS", 86400000L);
+        ReflectionTestUtils.setField(jwtCreator, "REFRESH_TOKEN_VALID_MILISECONDS", 5184000000L);
         Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Seoul"), Locale.KOREA);
         calendar.set(2080, Calendar.OCTOBER, 21, 11, 58, 30);
         when(dateFactory.now()).thenReturn(calendar.getTime());

--- a/knowlly-core/src/main/resources/application.yml
+++ b/knowlly-core/src/main/resources/application.yml
@@ -22,6 +22,8 @@ spring:
       # JWT
     jwt:
       secret: 12345678901234567890123456789012
+      access-token-valid-miliseconds: 86400000 # 24 시간
+      refresh-token-valid-miliseconds: 5184000000  # 2달
 
     mvc:
       pathmatch:


### PR DESCRIPTION
## 작업 내용 설명
- 리프레시 호출 시 db에 저장 로직 추가
- 리프레시 로직에서 db와 대조 로직 추가

## 주요 변경 사항
- 리프레시 호출 시 db에 저장 로직 추가
- 리프레시 로직에서 db와 대조 로직 추가
- 테스트 업데이트

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없는가?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였는가?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었는가?

## 관련 이슈
- resolved #76

@NaLDo627 @Park-Young-Hun
